### PR TITLE
feat: restore next-themes and localize mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,13 @@
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
     <title>Dietlog</title>
+    <script>
+      const theme = localStorage.getItem("vite-ui-theme");
+      const systemDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      if (theme === "dark" || (!theme && systemDark)) {
+        document.documentElement.classList.add("dark");
+      }
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -1,0 +1,32 @@
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useTheme } from "next-themes";
+import { useTranslate } from "@tolgee/react";
+
+export function ModeToggle() {
+  const { setTheme } = useTheme();
+  const { t } = useTranslate();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon">
+          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">{t("theme.toggle")}</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>{t("theme.light")}</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>{t("theme.dark")}</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>{t("theme.system")}</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,15 @@
+import { ThemeProvider as NextThemesProvider, type ThemeProviderProps } from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      storageKey="vite-ui-theme"
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import "./styles.css";
 import tolgee, { TolgeeProvider } from "@/lib/tolgee";
 import { QueryClient } from "@tanstack/react-query";
 import FullPageLoader from "./components/feedback/full-page-loader.tsx";
+import { ThemeProvider } from "@/components/theme-provider";
 
 const queryClient = new QueryClient();
 
@@ -41,9 +42,11 @@ if (rootElement && !rootElement.innerHTML) {
   const root = ReactDOM.createRoot(rootElement);
   root.render(
     <StrictMode>
-      <TolgeeProvider tolgee={tolgee} fallback={<FullPageLoader />}>
-        <RouterProvider router={router} />
-      </TolgeeProvider>
+      <ThemeProvider>
+        <TolgeeProvider tolgee={tolgee} fallback={<FullPageLoader />}>
+          <RouterProvider router={router} />
+        </TolgeeProvider>
+      </ThemeProvider>
     </StrictMode>
   );
 }

--- a/src/routes/__authenticatedLayout.tsx
+++ b/src/routes/__authenticatedLayout.tsx
@@ -6,6 +6,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
+import { ModeToggle } from "@/components/mode-toggle";
 import { account } from "@/lib/appwrite";
 import { Outlet } from "@tanstack/react-router";
 
@@ -57,6 +58,9 @@ function RouteComponent() {
         <header className="flex h-16 shrink-0 items-center gap-2">
           <div className="flex items-center gap-2 px-4">
             <SidebarTrigger className="-ml-1" />
+          </div>
+          <div className="ml-auto px-4">
+            <ModeToggle />
           </div>
         </header>
         <div className="flex flex-1 flex-col gap-4 p-4 pt-0">


### PR DESCRIPTION
## Summary
- reintroduce next-themes provider with system theme support and storage key
- localize ModeToggle labels via Tolgee translations

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689f622f5b28832eb89b2df2902e27c3