### PR TITLE
feat: update auth pages layout

### DIFF
--- a/src/routes/__authenticationLayout/login.tsx
+++ b/src/routes/__authenticationLayout/login.tsx
@@ -68,11 +68,11 @@ function RouteComponent() {
                   </div>
                 </div>
               </div>
-              <div className="relative hidden bg-muted md:block">
+              <div className="relative hidden bg-background md:flex md:items-center md:justify-center">
                 <img
                   src="/assets/mascot/mascot_default.png"
                   alt={t("login.welcomeBack")}
-                  className="absolute inset-0 h-full w-full object-cover dark:brightness-[0.2] dark:grayscale"
+                  className="h-32 w-32 object-contain"
                 />
               </div>
             </CardContent>

--- a/src/routes/__authenticationLayout/login.tsx
+++ b/src/routes/__authenticationLayout/login.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute("/__authenticationLayout/login")({
 function RouteComponent() {
   const { t } = useTranslate();
   return (
-    <div className="flex min-h-svh flex-col items-center justify-center bg-muted p-6 md:p-10">
+    <div className="flex min-h-svh flex-col items-center justify-center bg-muted py-6 md:py-10">
       <div className="w-full max-w-sm md:max-w-3xl">
         <div className={cn("flex flex-col gap-6")}>
           <Card className="overflow-hidden">

--- a/src/routes/__authenticationLayout/login.tsx
+++ b/src/routes/__authenticationLayout/login.tsx
@@ -3,13 +3,7 @@ import OAuth2Button from "@/components/login/oauth2-button";
 import AppleIcon from "@/components/svg-icons/apple";
 import GoogleIcon from "@/components/svg-icons/google";
 import { Badge } from "@/components/ui/badge";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useTranslate } from "@tolgee/react";
@@ -22,66 +16,69 @@ export const Route = createFileRoute("/__authenticationLayout/login")({
 function RouteComponent() {
   const { t } = useTranslate();
   return (
-    <div className="bg-muted flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
-      <div className="flex w-full max-w-sm flex-col gap-6">
-        {/*  <a href="#" className="flex items-center gap-2 self-center font-medium">
-          <div className="bg-primary text-primary-foreground flex size-6 items-center justify-center rounded-md">
-            <ChefHat className="size-4" />
-          </div>
-          Gojlevicius Inc.
-        </a> */}
+    <div className="flex min-h-svh flex-col items-center justify-center bg-muted p-6 md:p-10">
+      <div className="w-full max-w-sm md:max-w-3xl">
         <div className={cn("flex flex-col gap-6")}>
-          <Card>
-            <CardHeader className="text-center">
-              <CardTitle className="text-xl">
-                {t("login.welcomeBack")}
-              </CardTitle>
-              <CardDescription>
-                {t("login.loginWithAppleOrGoogle")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="grid gap-6">
-                <div className="flex flex-col gap-4">
-                  <div className="relative">
-                    <OAuth2Button
-                      icon={<AppleIcon />}
-                      provider={OAuthProvider.Apple}
-                      disabled
-                    >
-                      {t("login.loginWithApple")}
-                    </OAuth2Button>
-                    <Badge
-                      variant={"secondary"}
-                      className="absolute -top-2 -right-2"
-                    >
-                      {t("soon")}
-                    </Badge>
+          <Card className="overflow-hidden">
+            <CardContent className="grid p-0 md:grid-cols-2">
+              <div className="p-6 md:p-8">
+                <div className="flex flex-col gap-6">
+                  <div className="flex flex-col items-center text-center">
+                    <h1 className="text-2xl font-bold">
+                      {t("login.welcomeBack")}
+                    </h1>
+                    <p className="text-balance text-muted-foreground">
+                      {t("login.loginWithAppleOrGoogle")}
+                    </p>
                   </div>
-                  <OAuth2Button
-                    icon={<GoogleIcon />}
-                    provider={OAuthProvider.Google}
-                  >
-                    {t("login.loginWithGoogle")}
-                  </OAuth2Button>
+                  <div className="flex flex-col gap-4">
+                    <div className="relative">
+                      <OAuth2Button
+                        icon={<AppleIcon />}
+                        provider={OAuthProvider.Apple}
+                        disabled
+                      >
+                        {t("login.loginWithApple")}
+                      </OAuth2Button>
+                      <Badge
+                        variant={"secondary"}
+                        className="absolute -top-2 -right-2"
+                      >
+                        {t("soon")}
+                      </Badge>
+                    </div>
+                    <OAuth2Button
+                      icon={<GoogleIcon />}
+                      provider={OAuthProvider.Google}
+                    >
+                      {t("login.loginWithGoogle")}
+                    </OAuth2Button>
+                  </div>
+                  <div className="relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t after:border-border">
+                    <span className="relative z-10 bg-background px-2 text-muted-foreground">
+                      {t("login.orContinueWith")}
+                    </span>
+                  </div>
+                  <EmailAndPasswordForm />
+                  <div className="text-center text-sm">
+                    {t("login.dontHaveAccount")} {" "}
+                    <Link to="/register" className="underline underline-offset-4">
+                      {t("login.signUp")}
+                    </Link>
+                  </div>
                 </div>
-                <div className="after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t">
-                  <span className="bg-card text-muted-foreground relative z-10 px-2">
-                    {t("login.orContinueWith")}
-                  </span>
-                </div>
-                <EmailAndPasswordForm />
-                <div className="text-center text-sm">
-                  {t("login.dontHaveAccount")}{" "}
-                  <Link to="/register" className="underline underline-offset-4">
-                    {t("login.signUp")}
-                  </Link>
-                </div>
+              </div>
+              <div className="relative hidden bg-muted md:block">
+                <img
+                  src="/assets/mascot/mascot_default.png"
+                  alt={t("login.welcomeBack")}
+                  className="absolute inset-0 h-full w-full object-cover dark:brightness-[0.2] dark:grayscale"
+                />
               </div>
             </CardContent>
           </Card>
-          <div className="text-muted-foreground *:[a]:hover:text-primary text-center text-xs text-balance *:[a]:underline *:[a]:underline-offset-4">
-            {t("login.agreeTo")} <a href="#">{t("login.termsOfService")}</a>{" "}
+          <div className="text-balance text-center text-xs text-muted-foreground [&_a]:underline [&_a]:underline-offset-4 hover:[&_a]:text-primary">
+            {t("login.agreeTo")} <a href="#">{t("login.termsOfService")}</a> {" "}
             {t("login.and")} <a href="#">{t("login.privacyPolicy")}</a>.
           </div>
         </div>
@@ -89,3 +86,4 @@ function RouteComponent() {
     </div>
   );
 }
+

--- a/src/routes/__authenticationLayout/register.tsx
+++ b/src/routes/__authenticationLayout/register.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useTranslate } from "@tolgee/react";
 import { OAuthProvider } from "appwrite";
+import { useEffect, useState } from "react";
 
 export const Route = createFileRoute("/__authenticationLayout/register")({
   component: RouteComponent,
@@ -15,13 +16,22 @@ export const Route = createFileRoute("/__authenticationLayout/register")({
 
 function RouteComponent() {
   const { t } = useTranslate();
+  const [hideRight, setHideRight] = useState(false);
+  useEffect(() => {
+    setHideRight(true);
+  }, []);
   return (
-    <div className="flex min-h-svh flex-col items-center justify-center bg-muted p-6 md:p-10">
+    <div className="flex min-h-svh flex-col items-center justify-center bg-muted py-6 md:py-10">
       <div className="w-full max-w-sm md:max-w-3xl">
         <div className={cn("flex flex-col gap-6")}>
           <Card className="overflow-hidden">
-            <CardContent className="grid p-0 md:grid-cols-2">
-              <div className="p-6 md:p-8">
+            <CardContent className="p-0 md:flex">
+              <div
+                className={cn(
+                  "p-6 md:p-8 transition-all duration-500 md:w-1/2",
+                  hideRight && "md:w-full"
+                )}
+              >
                 <div className="flex flex-col gap-6">
                   <div className="flex flex-col items-center text-center">
                     <h1 className="text-2xl font-bold">
@@ -68,7 +78,12 @@ function RouteComponent() {
                   </div>
                 </div>
               </div>
-              <div className="relative hidden bg-muted md:block">
+              <div
+                className={cn(
+                  "relative hidden overflow-hidden bg-muted transition-all duration-500 md:block md:w-1/2",
+                  hideRight && "md:w-0 md:translate-x-full"
+                )}
+              >
                 <img
                   src="/assets/mascot/mascot_thumbs_up.png"
                   alt={t("register.createAccount")}

--- a/src/routes/__authenticationLayout/register.tsx
+++ b/src/routes/__authenticationLayout/register.tsx
@@ -22,7 +22,7 @@ function RouteComponent() {
   }, []);
   return (
     <div className="flex min-h-svh flex-col items-center justify-center bg-muted py-6 md:py-10">
-      <div className="w-full max-w-sm md:max-w-3xl">
+      <div className="w-full max-w-sm">
         <div className={cn("flex flex-col gap-6")}>
           <Card className="overflow-hidden">
             <CardContent className="p-0 md:flex">
@@ -80,14 +80,14 @@ function RouteComponent() {
               </div>
               <div
                 className={cn(
-                  "relative hidden overflow-hidden bg-muted transition-all duration-500 md:block md:w-1/2",
+                  "relative hidden bg-background transition-all duration-500 md:flex md:w-1/2 md:items-center md:justify-center",
                   hideRight && "md:w-0 md:translate-x-full"
                 )}
               >
                 <img
                   src="/assets/mascot/mascot_thumbs_up.png"
                   alt={t("register.createAccount")}
-                  className="absolute inset-0 h-full w-full object-cover dark:brightness-[0.2] dark:grayscale"
+                  className="h-32 w-32 object-contain"
                 />
               </div>
             </CardContent>

--- a/src/routes/__authenticationLayout/register.tsx
+++ b/src/routes/__authenticationLayout/register.tsx
@@ -3,13 +3,7 @@ import OAuth2Button from "@/components/login/oauth2-button";
 import AppleIcon from "@/components/svg-icons/apple";
 import GoogleIcon from "@/components/svg-icons/google";
 import { Badge } from "@/components/ui/badge";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useTranslate } from "@tolgee/react";
@@ -22,60 +16,69 @@ export const Route = createFileRoute("/__authenticationLayout/register")({
 function RouteComponent() {
   const { t } = useTranslate();
   return (
-    <div className="bg-muted flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
-      <div className="flex w-full max-w-sm flex-col gap-6">
+    <div className="flex min-h-svh flex-col items-center justify-center bg-muted p-6 md:p-10">
+      <div className="w-full max-w-sm md:max-w-3xl">
         <div className={cn("flex flex-col gap-6")}>
-          <Card>
-            <CardHeader className="text-center">
-              <CardTitle className="text-xl">
-                {t("register.createAccount")}
-              </CardTitle>
-              <CardDescription>
-                {t("register.signUpWithAppleOrGoogle")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="grid gap-6">
-                <div className="flex flex-col gap-4">
-                  <div className="relative">
-                    <OAuth2Button
-                      icon={<AppleIcon />}
-                      provider={OAuthProvider.Apple}
-                      disabled
-                    >
-                      {t("register.signUpWithApple")}
-                    </OAuth2Button>
-                    <Badge
-                      variant={"secondary"}
-                      className="absolute -top-2 -right-2"
-                    >
-                      {t("soon")}
-                    </Badge>
+          <Card className="overflow-hidden">
+            <CardContent className="grid p-0 md:grid-cols-2">
+              <div className="p-6 md:p-8">
+                <div className="flex flex-col gap-6">
+                  <div className="flex flex-col items-center text-center">
+                    <h1 className="text-2xl font-bold">
+                      {t("register.createAccount")}
+                    </h1>
+                    <p className="text-balance text-muted-foreground">
+                      {t("register.signUpWithAppleOrGoogle")}
+                    </p>
                   </div>
-                  <OAuth2Button
-                    icon={<GoogleIcon />}
-                    provider={OAuthProvider.Google}
-                  >
-                    {t("register.signUpWithGoogle")}
-                  </OAuth2Button>
+                  <div className="flex flex-col gap-4">
+                    <div className="relative">
+                      <OAuth2Button
+                        icon={<AppleIcon />}
+                        provider={OAuthProvider.Apple}
+                        disabled
+                      >
+                        {t("register.signUpWithApple")}
+                      </OAuth2Button>
+                      <Badge
+                        variant={"secondary"}
+                        className="absolute -top-2 -right-2"
+                      >
+                        {t("soon")}
+                      </Badge>
+                    </div>
+                    <OAuth2Button
+                      icon={<GoogleIcon />}
+                      provider={OAuthProvider.Google}
+                    >
+                      {t("register.signUpWithGoogle")}
+                    </OAuth2Button>
+                  </div>
+                  <div className="relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t after:border-border">
+                    <span className="relative z-10 bg-background px-2 text-muted-foreground">
+                      {t("register.orContinueWith")}
+                    </span>
+                  </div>
+                  <RegisterEmailAndPasswordForm />
+                  <div className="text-center text-sm">
+                    {t("register.alreadyHaveAccount")} {" "}
+                    <Link to="/login" className="underline underline-offset-4">
+                      {t("register.login")}
+                    </Link>
+                  </div>
                 </div>
-                <div className="after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t">
-                  <span className="bg-card text-muted-foreground relative z-10 px-2">
-                    {t("register.orContinueWith")}
-                  </span>
-                </div>
-                <RegisterEmailAndPasswordForm />
-                <div className="text-center text-sm">
-                  {t("register.alreadyHaveAccount")} {""}
-                  <Link to="/login" className="underline underline-offset-4">
-                    {t("register.login")}
-                  </Link>
-                </div>
+              </div>
+              <div className="relative hidden bg-muted md:block">
+                <img
+                  src="/assets/mascot/mascot_thumbs_up.png"
+                  alt={t("register.createAccount")}
+                  className="absolute inset-0 h-full w-full object-cover dark:brightness-[0.2] dark:grayscale"
+                />
               </div>
             </CardContent>
           </Card>
-          <div className="text-muted-foreground *:[a]:hover:text-primary text-center text-xs text-balance *:[a]:underline *:[a]:underline-offset-4">
-            {t("register.agreeTo")} <a href="#">{t("register.termsOfService")}</a> {""}
+          <div className="text-balance text-center text-xs text-muted-foreground [&_a]:underline [&_a]:underline-offset-4 hover:[&_a]:text-primary">
+            {t("register.agreeTo")} <a href="#">{t("register.termsOfService")}</a> {" "}
             {t("register.and")} <a href="#">{t("register.privacyPolicy")}</a>.
           </div>
         </div>


### PR DESCRIPTION
## Summary
- restyle login page with side-image login-04 layout
- restyle registration page to match new login style

## Testing
- `pnpm test` *(fails: No test files found)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689f69723e7c832eadc75d1e18bbe975