### PR TITLE
feat: add chat page template

### DIFF
--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -1,0 +1,46 @@
+import * as React from "react";
+
+export type ChatMessage = {
+  role: "user" | "bot";
+  content: string;
+};
+
+export function useChat() {
+  const [messages, setMessages] = React.useState<ChatMessage[]>([]);
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const sendMessage = React.useCallback(async (content: string) => {
+    const userMessage: ChatMessage = { role: "user", content };
+    setMessages((prev) => [...prev, userMessage]);
+    setIsLoading(true);
+
+    try {
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: content }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setMessages((prev) => [
+          ...prev,
+          { role: "bot", content: data.reply ?? "" },
+        ]);
+      } else {
+        setMessages((prev) => [
+          ...prev,
+          { role: "bot", content: "Erro no servidor" },
+        ]);
+      }
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        { role: "bot", content: "Erro de conexao" },
+      ]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { messages, sendMessage, isLoading };
+}

--- a/src/routes/__authenticatedLayout/chat.tsx
+++ b/src/routes/__authenticatedLayout/chat.tsx
@@ -1,13 +1,121 @@
+import * as React from "react";
 import { createFileRoute } from "@tanstack/react-router";
 
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { useChat } from "@/hooks/use-chat";
+import { Send, Loader2 } from "lucide-react";
+
 export const Route = createFileRoute("/__authenticatedLayout/chat")({
-  component: RouteComponent,
+  component: ChatPage,
 });
 
-function RouteComponent() {
+function ChatPage() {
+  const [input, setInput] = React.useState("");
+  const { messages, sendMessage, isLoading } = useChat();
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+  const endRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  React.useEffect(() => {
+    if (!textareaRef.current) return;
+    textareaRef.current.style.height = "auto";
+    textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+  }, [input]);
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const value = input.trim();
+    if (!value) return;
+    sendMessage(value);
+    setInput("");
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      onSubmit(e);
+    }
+  }
+
   return (
-    <div className="w-full h-full flex  justify-center items-center">
-      <p className="font-mono text-3xl">Em desenvolvimento</p>
+    <div className="flex h-full w-full items-center justify-center p-4">
+      <Card className="flex h-full w-full max-w-2xl flex-col">
+        <CardHeader>
+          <CardTitle>Chat</CardTitle>
+        </CardHeader>
+        <CardContent className="flex-1 overflow-y-auto space-y-4">
+          {messages.map((m, i) => (
+            <div
+              key={i}
+              className={`flex items-end gap-2 ${
+                m.role === "user" ? "justify-end" : "justify-start"
+              }`}
+            >
+              {m.role === "bot" && (
+                <Avatar>
+                  <AvatarFallback>AI</AvatarFallback>
+                </Avatar>
+              )}
+              <div
+                className={
+                  m.role === "user"
+                    ? "bg-primary text-primary-foreground rounded-xl px-3 py-2"
+                    : "bg-muted text-muted-foreground rounded-xl px-3 py-2"
+                }
+              >
+                {m.content}
+              </div>
+              {m.role === "user" && (
+                <Avatar>
+                  <AvatarFallback>Você</AvatarFallback>
+                </Avatar>
+              )}
+            </div>
+          ))}
+          <div ref={endRef} />
+        </CardContent>
+        <CardFooter>
+          <form onSubmit={onSubmit} className="w-full">
+            <div className="relative flex items-center">
+              <Textarea
+                ref={textareaRef}
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={onKeyDown}
+                placeholder="Digite sua mensagem..."
+                className="min-h-[44px] resize-none pr-12"
+                rows={1}
+                disabled={isLoading}
+              />
+              <Button
+                type="submit"
+                size="icon"
+                className="absolute bottom-1.5 right-1.5"
+                disabled={isLoading || !input.trim()}
+              >
+                {isLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Send className="h-4 w-4" />
+                )}
+                <span className="sr-only">Enviar</span>
+              </Button>
+            </div>
+          </form>
+        </CardFooter>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- modernize chat page with avatars, auto-scroll, and message bubbles
- introduce auto-resizing textarea with send button and loading state
- expose `isLoading` from `useChat` for interactive messaging

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689f904d1088832ea0134fefe73db883