### PR TITLE
feat: add responsive chat ui

### DIFF
--- a/src/components/chat/chat-header.tsx
+++ b/src/components/chat/chat-header.tsx
@@ -1,0 +1,34 @@
+import { Button } from "@/components/ui/button";
+import { Trash2, RefreshCcw } from "lucide-react";
+
+interface ChatHeaderProps {
+  onClear: () => void;
+}
+
+export function ChatHeader({ onClear }: ChatHeaderProps) {
+  return (
+    <header className="flex items-center justify-between border-b px-4 py-2">
+      <h1 className="text-lg font-semibold">Chat</h1>
+      <div className="flex gap-2">
+        <Button
+          size="icon"
+          variant="ghost"
+          aria-label="Nova conversa"
+          onClick={onClear}
+        >
+          <RefreshCcw className="size-5" />
+        </Button>
+        <Button
+          size="icon"
+          variant="ghost"
+          aria-label="Limpar mensagens"
+          onClick={onClear}
+        >
+          <Trash2 className="size-5" />
+        </Button>
+      </div>
+    </header>
+  );
+}
+
+export default ChatHeader;

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { Paperclip, Send, X, Mic } from "lucide-react";
+
+interface ChatInputProps {
+  value: string;
+  onChange: (v: string) => void;
+  onSend: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+  placeholder?: string;
+}
+
+export function ChatInput({
+  value,
+  onChange,
+  onSend,
+  disabled,
+  loading,
+  placeholder,
+}: ChatInputProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [value]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      if (!loading && !disabled) onSend();
+    }
+  };
+
+  return (
+    <div className="w-full flex items-end gap-2">
+      <Button
+        size="icon"
+        variant="ghost"
+        aria-label="Anexar arquivo"
+        onClick={() => {}}
+        disabled={disabled || loading}
+      >
+        <Paperclip className="size-5" />
+      </Button>
+      <div className="relative flex-1">
+        <textarea
+          ref={textareaRef}
+          rows={1}
+          className="w-full resize-none rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+          placeholder={placeholder}
+          aria-label="Mensagem"
+          value={value}
+          disabled={disabled || loading}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <span className="absolute bottom-1 right-2 text-xs text-muted-foreground">
+          {value.length}
+        </span>
+      </div>
+      <Button
+        size="icon"
+        variant="ghost"
+        aria-label="Limpar"
+        onClick={() => onChange("")}
+        disabled={disabled || loading || value.length === 0}
+      >
+        <X className="size-5" />
+      </Button>
+      <Button
+        size="icon"
+        aria-label="Enviar"
+        onClick={onSend}
+        disabled={disabled || loading || value.length === 0}
+        loading={loading}
+      >
+        <Send className="size-5" />
+      </Button>
+      <Button
+        size="icon"
+        variant="ghost"
+        aria-label="Microfone"
+        onClick={() => {}}
+        disabled={disabled || loading}
+      >
+        <Mic className="size-5" />
+      </Button>
+    </div>
+  );
+}
+
+export default ChatInput;

--- a/src/components/chat/message-bubble.tsx
+++ b/src/components/chat/message-bubble.tsx
@@ -1,0 +1,52 @@
+import { cn } from "@/lib/utils";
+import { Loader2, AlertCircle } from "lucide-react";
+import { useEffect, useRef } from "react";
+
+interface MessageBubbleProps {
+  role: "user" | "ai";
+  content: string;
+  timestamp: Date;
+  status?: "sending" | "error" | "sent";
+}
+
+function basicMarkdown(text: string) {
+  return text
+    .replace(/`([^`]+)`/g, '<code class="bg-muted px-1 rounded">$1<\/code>')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer" class="text-primary underline">$1<\/a>');
+}
+
+export function MessageBubble({ role, content, timestamp, status = "sent" }: MessageBubbleProps) {
+  const isUser = role === "user";
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    ref.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "flex w-full gap-2 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2",
+        isUser ? "justify-end" : "justify-start"
+      )}
+    >
+      <div
+        className={cn(
+          "rounded-lg px-3 py-2 max-w-[85%] sm:max-w-[70%] break-words",
+          isUser ? "bg-primary text-primary-foreground" : "bg-muted"
+        )}
+      >
+        <div
+          className="prose prose-sm dark:prose-invert"
+          dangerouslySetInnerHTML={{ __html: basicMarkdown(content) }}
+        />
+        <div className="flex items-center justify-end gap-1 mt-1 text-[10px] text-muted-foreground">
+          {status === "sending" && <Loader2 className="size-3 animate-spin" />}
+          {status === "error" && <AlertCircle className="size-3 text-destructive" />}
+          <span>{timestamp.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MessageBubble;

--- a/src/routes/__authenticatedLayout/chat.tsx
+++ b/src/routes/__authenticatedLayout/chat.tsx
@@ -1,13 +1,84 @@
+import ChatHeader from "@/components/chat/chat-header";
+import ChatInput from "@/components/chat/chat-input";
+import MessageBubble from "@/components/chat/message-bubble";
 import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useRef, useState } from "react";
+
+interface ChatMessage {
+  id: string;
+  role: "user" | "ai";
+  content: string;
+  timestamp: Date;
+  status: "sending" | "sent" | "error";
+}
 
 export const Route = createFileRoute("/__authenticatedLayout/chat")({
-  component: RouteComponent,
+  component: ChatRoute,
 });
 
-function RouteComponent() {
+function ChatRoute() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const handleSend = () => {
+    if (!input.trim()) return;
+    const id = Date.now().toString();
+    const userMsg: ChatMessage = {
+      id,
+      role: "user",
+      content: input.trim(),
+      timestamp: new Date(),
+      status: "sending",
+    };
+    setMessages((msgs) => [...msgs, userMsg]);
+    setInput("");
+    setLoading(true);
+
+    setTimeout(() => {
+      setMessages((msgs) =>
+        msgs.map((m) => (m.id === id ? { ...m, status: "sent" } : m))
+      );
+      const fail = userMsg.content.toLowerCase().includes("erro");
+      const aiMsg: ChatMessage = {
+        id: `${Date.now()}-ai`,
+        role: "ai",
+        content: fail
+          ? "Algo deu errado"
+          : `Você disse: ${userMsg.content}`,
+        timestamp: new Date(),
+        status: fail ? "error" : "sent",
+      };
+      setMessages((msgs) => [...msgs, aiMsg]);
+      setLoading(false);
+    }, 1000);
+  };
+
+  const clearMessages = () => setMessages([]);
+
   return (
-    <div className="w-full h-full flex  justify-center items-center">
-      <p className="font-mono text-3xl">Em desenvolvimento</p>
+    <div className="flex h-full w-full flex-col">
+      <ChatHeader onClear={clearMessages} />
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {messages.map((m) => (
+          <MessageBubble key={m.id} {...m} />
+        ))}
+        <div ref={endRef} />
+      </div>
+      <div className="border-t p-4">
+        <ChatInput
+          value={input}
+          onChange={setInput}
+          onSend={handleSend}
+          loading={loading}
+          placeholder={loading ? "Gerando resposta..." : "Digite sua mensagem"}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add chat header with action buttons
- implement message bubbles with markdown and status indicators
- create chat input with auto-resize, controls and accessibility
- wire up /chat route with autoscroll and mock AI reply

## Testing
- `pnpm test` *(fails: No test files found)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689f9ace6dd0832eac1e9696dda26b24