### PR TITLE
Add branding to login illustration

### DIFF
--- a/src/routes/__authenticationLayout/login.tsx
+++ b/src/routes/__authenticationLayout/login.tsx
@@ -69,11 +69,22 @@ function RouteComponent() {
                 </div>
               </div>
               <div className="relative hidden bg-background md:flex md:items-center md:justify-center">
-                <img
-                  src="/assets/mascot/mascot_default.png"
-                  alt={t("login.welcomeBack")}
-                  className="h-32 w-32 object-contain"
-                />
+                <div className="flex flex-col items-center text-center">
+                  <div className="relative">
+                    <span className="absolute -inset-2 rounded-full bg-orange-200 opacity-50 blur-md animate-pulse"></span>
+                    <img
+                      src="/assets/mascot/mascot_default.png"
+                      alt={t("login.welcomeBack")}
+                      className="relative h-32 w-32 object-contain animate-bounce"
+                    />
+                  </div>
+                  <h2 className="mt-4 text-2xl font-bold text-orange-500">
+                    {t("login.appName")}
+                  </h2>
+                  <p className="text-sm text-muted-foreground">
+                    {t("login.funDescription")}
+                  </p>
+                </div>
               </div>
             </CardContent>
           </Card>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -26,7 +26,9 @@
     "privacyPolicy": "Privacy Policy",
     "signUp": "Sign up",
     "termsOfService": "Terms of Service",
-    "welcomeBack": "Welcome back"
+    "welcomeBack": "Welcome back",
+    "appName": "Laranjito",
+    "funDescription": "Your juicy sidekick!"
   },
   "register": {
     "agreeTo": "By clicking sign up, you agree to our",

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -26,7 +26,9 @@
     "privacyPolicy": "Política de Privacidade",
     "signUp": "Cadastre-se",
     "termsOfService": "Termos de Serviço",
-    "welcomeBack": "Bem-vindo de volta"
+    "welcomeBack": "Bem-vindo de volta",
+    "appName": "Laranjito",
+    "funDescription": "Seu companheiro suculento!"
   },
   "register": {
     "agreeTo": "Ao clicar em cadastrar, você concorda com nossos",


### PR DESCRIPTION
## Summary
- add pulsing ring, app name and fun description around login mascot
- localize brand text in English and Portuguese translations

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689fade8fa30832e9cdaf1035ae8c648