### PR TITLE
chore: add tolgee push workflow

### DIFF
--- a/.github/workflows/tolgee-push.yml
+++ b/.github/workflows/tolgee-push.yml
@@ -1,0 +1,26 @@
+name: Update Tolgee translations
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  push-translations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Push translations to Tolgee
+        run: |
+          npx @tolgee/cli push \
+            --api-url "$TOLGEE_API_URL" \
+            --api-key "$TOLGEE_API_KEY" \
+            --files-template "src/translations/{languageTag}.json" \
+            --force-mode OVERRIDE
+        env:
+          TOLGEE_API_URL: ${{ vars.TOLGEE_API_URL }}
+          TOLGEE_API_KEY: ${{ vars.TOLGEE_API_KEY }}
+


### PR DESCRIPTION
## Summary
- add GitHub Action to push translations to Tolgee after main deployments
- use GitHub repository variables for Tolgee API URL and key

## Testing
- `npm test` *(fails: No test files found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fbb3dd72c832e99efdecb5f54851c