### PR TITLE
Add waitlist signup page

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as WaitlistRouteImport } from './routes/waitlist'
 import { Route as _authenticationLayoutRouteImport } from './routes/__authenticationLayout'
 import { Route as _authenticatedLayoutRouteImport } from './routes/__authenticatedLayout'
 import { Route as _authenticatedLayoutIndexRouteImport } from './routes/__authenticatedLayout/index'
@@ -17,6 +18,11 @@ import { Route as _authenticationLayoutLoginRouteImport } from './routes/__authe
 import { Route as _authenticatedLayoutHomeRouteImport } from './routes/__authenticatedLayout/home'
 import { Route as _authenticatedLayoutChatRouteImport } from './routes/__authenticatedLayout/chat'
 
+const WaitlistRoute = WaitlistRouteImport.update({
+  id: '/waitlist',
+  path: '/waitlist',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const _authenticationLayoutRoute = _authenticationLayoutRouteImport.update({
   id: '/__authenticationLayout',
   getParentRoute: () => rootRouteImport,
@@ -57,6 +63,7 @@ const _authenticatedLayoutChatRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
+  '/waitlist': typeof WaitlistRoute
   '/chat': typeof _authenticatedLayoutChatRoute
   '/home': typeof _authenticatedLayoutHomeRoute
   '/login': typeof _authenticationLayoutLoginRoute
@@ -64,6 +71,7 @@ export interface FileRoutesByFullPath {
   '/': typeof _authenticatedLayoutIndexRoute
 }
 export interface FileRoutesByTo {
+  '/waitlist': typeof WaitlistRoute
   '/chat': typeof _authenticatedLayoutChatRoute
   '/home': typeof _authenticatedLayoutHomeRoute
   '/login': typeof _authenticationLayoutLoginRoute
@@ -74,6 +82,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/__authenticatedLayout': typeof _authenticatedLayoutRouteWithChildren
   '/__authenticationLayout': typeof _authenticationLayoutRouteWithChildren
+  '/waitlist': typeof WaitlistRoute
   '/__authenticatedLayout/chat': typeof _authenticatedLayoutChatRoute
   '/__authenticatedLayout/home': typeof _authenticatedLayoutHomeRoute
   '/__authenticationLayout/login': typeof _authenticationLayoutLoginRoute
@@ -82,13 +91,14 @@ export interface FileRoutesById {
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/chat' | '/home' | '/login' | '/register' | '/'
+  fullPaths: '/waitlist' | '/chat' | '/home' | '/login' | '/register' | '/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/chat' | '/home' | '/login' | '/register' | '/'
+  to: '/waitlist' | '/chat' | '/home' | '/login' | '/register' | '/'
   id:
     | '__root__'
     | '/__authenticatedLayout'
     | '/__authenticationLayout'
+    | '/waitlist'
     | '/__authenticatedLayout/chat'
     | '/__authenticatedLayout/home'
     | '/__authenticationLayout/login'
@@ -99,10 +109,18 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   _authenticatedLayoutRoute: typeof _authenticatedLayoutRouteWithChildren
   _authenticationLayoutRoute: typeof _authenticationLayoutRouteWithChildren
+  WaitlistRoute: typeof WaitlistRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/waitlist': {
+      id: '/waitlist'
+      path: '/waitlist'
+      fullPath: '/waitlist'
+      preLoaderRoute: typeof WaitlistRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/__authenticationLayout': {
       id: '/__authenticationLayout'
       path: ''
@@ -188,6 +206,7 @@ const _authenticationLayoutRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   _authenticatedLayoutRoute: _authenticatedLayoutRouteWithChildren,
   _authenticationLayoutRoute: _authenticationLayoutRouteWithChildren,
+  WaitlistRoute: WaitlistRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/waitlist.tsx
+++ b/src/routes/waitlist.tsx
@@ -1,0 +1,100 @@
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import { createFileRoute } from "@tanstack/react-router";
+import { useTranslate } from "@tolgee/react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "sonner";
+
+export const Route = createFileRoute("/waitlist")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { t } = useTranslate();
+
+  const formSchema = z.object({
+    email: z
+      .string()
+      .nonempty({ message: t("validation.required") })
+      .refine((val) => z.email().safeParse(val).success, {
+        message: t("validation.invalidEmail"),
+      }),
+  });
+
+  type IFormValues = z.infer<typeof formSchema>;
+
+  const formMethods = useForm<IFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { email: "" },
+  });
+
+  const onSubmit = formMethods.handleSubmit((values) => {
+    console.log("waitlist email", values.email);
+    toast.success(t("waitlist.success"));
+    formMethods.reset();
+  });
+
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center bg-muted py-6 md:py-10">
+      <div className="w-full max-w-sm md:max-w-lg">
+        <Card className="overflow-hidden">
+          <CardContent className="p-0 md:grid md:grid-cols-2">
+            <div className="flex flex-col gap-6 p-6 md:p-8">
+              <div className="flex flex-col items-center text-center gap-2">
+                <h1 className="text-2xl font-bold">{t("waitlist.joinWaitlist")}</h1>
+                <p className="text-balance text-muted-foreground">
+                  {t("waitlist.description")}
+                </p>
+              </div>
+              <Form {...formMethods}>
+                <form onSubmit={onSubmit} className="grid gap-4">
+                  <FormField
+                    control={formMethods.control}
+                    name="email"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("waitlist.email")}</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="email"
+                            placeholder={t("waitlist.email-placeholder")}
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <Button type="submit" className="w-full">
+                    {t("waitlist.join")}
+                  </Button>
+                </form>
+              </Form>
+            </div>
+            <div className="relative hidden bg-background md:flex md:items-center md:justify-center">
+              <img
+                src="/assets/mascot/mascot_thumbs_up.png"
+                alt={t("waitlist.joinWaitlist")}
+                className="w-52 object-contain"
+              />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default RouteComponent;
+

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -48,6 +48,14 @@
     "signUpWithGoogle": "Sign up with Google",
     "termsOfService": "Terms of Service"
   },
+  "waitlist": {
+    "joinWaitlist": "Join our waiting list",
+    "description": "Be the first to know when we launch.",
+    "email": "Email",
+    "email-placeholder": "Write here...",
+    "join": "Join waitlist",
+    "success": "You're on the list!"
+  },
   "soon": "Soon",
   "validation": {
     "invalidEmail": "Invalid email",

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -48,6 +48,14 @@
     "signUpWithGoogle": "Cadastre-se com Google",
     "termsOfService": "Termos de Serviço"
   },
+  "waitlist": {
+    "joinWaitlist": "Entre na lista de espera",
+    "description": "Seja avisado quando lançarmos.",
+    "email": "Email",
+    "email-placeholder": "Digite aqui...",
+    "join": "Entrar na lista",
+    "success": "Você entrou na lista!"
+  },
   "soon": "Em breve",
   "validation": {
     "invalidEmail": "Email inválido",


### PR DESCRIPTION
## Summary
- add a waitlist page with an email form and mascot graphic
- include translations for the waitlist page in English and Portuguese

## Testing
- `pnpm build`
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689fd6e0f004832eb96eac79ce0f0c0b