### PR TITLE
feat: add waitlist page

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as WaitlistRouteImport } from './routes/waitlist'
 import { Route as _authenticationLayoutRouteImport } from './routes/__authenticationLayout'
 import { Route as _authenticatedLayoutRouteImport } from './routes/__authenticatedLayout'
 import { Route as _authenticatedLayoutIndexRouteImport } from './routes/__authenticatedLayout/index'
@@ -17,6 +18,11 @@ import { Route as _authenticationLayoutLoginRouteImport } from './routes/__authe
 import { Route as _authenticatedLayoutHomeRouteImport } from './routes/__authenticatedLayout/home'
 import { Route as _authenticatedLayoutChatRouteImport } from './routes/__authenticatedLayout/chat'
 
+const WaitlistRoute = WaitlistRouteImport.update({
+  id: '/waitlist',
+  path: '/waitlist',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const _authenticationLayoutRoute = _authenticationLayoutRouteImport.update({
   id: '/__authenticationLayout',
   getParentRoute: () => rootRouteImport,
@@ -57,6 +63,7 @@ const _authenticatedLayoutChatRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
+  '/waitlist': typeof WaitlistRoute
   '/chat': typeof _authenticatedLayoutChatRoute
   '/home': typeof _authenticatedLayoutHomeRoute
   '/login': typeof _authenticationLayoutLoginRoute
@@ -64,6 +71,7 @@ export interface FileRoutesByFullPath {
   '/': typeof _authenticatedLayoutIndexRoute
 }
 export interface FileRoutesByTo {
+  '/waitlist': typeof WaitlistRoute
   '/chat': typeof _authenticatedLayoutChatRoute
   '/home': typeof _authenticatedLayoutHomeRoute
   '/login': typeof _authenticationLayoutLoginRoute
@@ -74,6 +82,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/__authenticatedLayout': typeof _authenticatedLayoutRouteWithChildren
   '/__authenticationLayout': typeof _authenticationLayoutRouteWithChildren
+  '/waitlist': typeof WaitlistRoute
   '/__authenticatedLayout/chat': typeof _authenticatedLayoutChatRoute
   '/__authenticatedLayout/home': typeof _authenticatedLayoutHomeRoute
   '/__authenticationLayout/login': typeof _authenticationLayoutLoginRoute
@@ -82,13 +91,14 @@ export interface FileRoutesById {
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/chat' | '/home' | '/login' | '/register' | '/'
+  fullPaths: '/waitlist' | '/chat' | '/home' | '/login' | '/register' | '/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/chat' | '/home' | '/login' | '/register' | '/'
+  to: '/waitlist' | '/chat' | '/home' | '/login' | '/register' | '/'
   id:
     | '__root__'
     | '/__authenticatedLayout'
     | '/__authenticationLayout'
+    | '/waitlist'
     | '/__authenticatedLayout/chat'
     | '/__authenticatedLayout/home'
     | '/__authenticationLayout/login'
@@ -99,10 +109,18 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   _authenticatedLayoutRoute: typeof _authenticatedLayoutRouteWithChildren
   _authenticationLayoutRoute: typeof _authenticationLayoutRouteWithChildren
+  WaitlistRoute: typeof WaitlistRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/waitlist': {
+      id: '/waitlist'
+      path: '/waitlist'
+      fullPath: '/waitlist'
+      preLoaderRoute: typeof WaitlistRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/__authenticationLayout': {
       id: '/__authenticationLayout'
       path: ''
@@ -188,6 +206,7 @@ const _authenticationLayoutRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   _authenticatedLayoutRoute: _authenticatedLayoutRouteWithChildren,
   _authenticationLayoutRoute: _authenticationLayoutRouteWithChildren,
+  WaitlistRoute: WaitlistRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/waitlist.tsx
+++ b/src/routes/waitlist.tsx
@@ -1,0 +1,93 @@
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { useTranslate } from "@tolgee/react";
+import { toast } from "sonner";
+
+export const Route = createFileRoute("/waitlist")({
+  component: WaitlistPage,
+});
+
+function WaitlistPage() {
+  const { t } = useTranslate();
+
+  const formSchema = z.object({
+    email: z
+      .string()
+      .nonempty({ message: t("validation.required") })
+      .email(t("validation.invalidEmail")),
+  });
+
+  type FormValues = z.infer<typeof formSchema>;
+
+  const formMethods = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { email: "" },
+  });
+
+  const onSubmit = (_values: FormValues) => {
+    // Placeholder for submission logic
+    toast.success(t("waitlist.success"));
+    formMethods.reset();
+  };
+
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center bg-muted p-4">
+      <Card className="w-full max-w-md">
+        <CardContent className="flex flex-col items-center gap-6 p-6 text-center">
+          <img
+            src="/assets/mascot/mascot_full_body.png"
+            alt="Mascot"
+            className="h-32 w-32 object-contain"
+          />
+          <h1 className="text-2xl font-bold">{t("waitlist.title")}</h1>
+          <p className="text-muted-foreground">
+            {t("waitlist.description")}
+          </p>
+          <Form {...formMethods}>
+            <form
+              onSubmit={formMethods.handleSubmit(onSubmit)}
+              className="flex w-full flex-col gap-4"
+            >
+              <FormField
+                control={formMethods.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("waitlist.email")}</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="email"
+                        placeholder={t("waitlist.email-placeholder")}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Button type="submit" className="w-full">
+                {t("waitlist.button")}
+              </Button>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default WaitlistPage;
+

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -48,6 +48,14 @@
     "signUpWithGoogle": "Sign up with Google",
     "termsOfService": "Terms of Service"
   },
+  "waitlist": {
+    "title": "Join the waitlist",
+    "description": "Leave your email and we'll keep you posted!",
+    "email": "Email",
+    "email-placeholder": "you@example.com",
+    "button": "Join waitlist",
+    "success": "Thanks for joining!"
+  },
   "soon": "Soon",
   "validation": {
     "invalidEmail": "Invalid email",

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -48,6 +48,14 @@
     "signUpWithGoogle": "Cadastre-se com Google",
     "termsOfService": "Termos de Serviço"
   },
+  "waitlist": {
+    "title": "Entre na lista de espera",
+    "description": "Deixe seu email e avisaremos você!",
+    "email": "Email",
+    "email-placeholder": "voce@exemplo.com",
+    "button": "Entrar na lista",
+    "success": "Obrigado por se inscrever!"
+  },
   "soon": "Em breve",
   "validation": {
     "invalidEmail": "Email inválido",


### PR DESCRIPTION
## Summary
- add localized waitlist route with email capture form and mascot artwork
- include translations for English and Portuguese
- update generated route tree

## Testing
- `pnpm build`
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689fd6e0f004832eb96eac79ce0f0c0b