### PR TITLE
fix: use dynamic viewport height on mobile

### DIFF
--- a/src/components/feedback/full-page-not-found.tsx
+++ b/src/components/feedback/full-page-not-found.tsx
@@ -7,7 +7,7 @@ export default function FullPageNotFound() {
   const { t } = useTranslate();
   const navigate = useNavigate();
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background to-muted flex items-center justify-center p-4">
+    <div className="min-h-dvh bg-gradient-to-br from-background to-muted flex items-center justify-center p-4">
       <div className="text-center max-w-md mx-auto">
         {/* Logo */}
         <div className="mb-8">

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -137,7 +137,7 @@ function SidebarProvider({
             } as React.CSSProperties
           }
           className={cn(
-            "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+            "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-dvh w-full",
             className
           )}
           {...props}

--- a/src/routes/__authenticationLayout/login.tsx
+++ b/src/routes/__authenticationLayout/login.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute("/__authenticationLayout/login")({
 function RouteComponent() {
   const { t } = useTranslate();
   return (
-    <div className="flex min-h-svh flex-col items-center justify-center bg-muted py-6 md:py-10">
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-muted py-6 md:py-10">
       <div className="w-full max-w-sm md:max-w-3xl">
         <div className={cn("flex flex-col gap-6")}>
           <Card className="overflow-hidden">

--- a/src/routes/__authenticationLayout/register.tsx
+++ b/src/routes/__authenticationLayout/register.tsx
@@ -21,7 +21,7 @@ function RouteComponent() {
     setHideRight(true);
   }, []);
   return (
-    <div className="flex min-h-svh flex-col items-center justify-center bg-muted py-6 md:py-10">
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-muted py-6 md:py-10">
       <div className="w-full max-w-sm">
         <div className={cn("flex flex-col gap-6")}>
           <Card className="overflow-hidden">

--- a/src/routes/waitlist.tsx
+++ b/src/routes/waitlist.tsx
@@ -20,7 +20,7 @@ function WaitlistPage() {
   };
 
   return (
-    <div className="flex min-h-svh flex-col items-center justify-center bg-muted px-4 py-10">
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-muted px-4 py-10">
       <div className="w-full max-w-md">
         <div className="flex flex-col items-center gap-6 text-center">
           <img


### PR DESCRIPTION
## Summary
- use dynamic viewport units to stabilize page height on iOS
- replace remaining `min-h-svh`/`min-h-screen` usages with `min-h-dvh`

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a00fc89dfc832e95ed373576650646