### PR TITLE
feat: add contact us route

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WaitlistRouteImport } from './routes/waitlist'
+import { Route as ContactUsRouteImport } from './routes/contact-us'
 import { Route as _authenticationLayoutRouteImport } from './routes/__authenticationLayout'
 import { Route as _authenticatedLayoutRouteImport } from './routes/__authenticatedLayout'
 import { Route as _authenticatedLayoutIndexRouteImport } from './routes/__authenticatedLayout/index'
@@ -21,6 +22,11 @@ import { Route as _authenticatedLayoutChatRouteImport } from './routes/__authent
 const WaitlistRoute = WaitlistRouteImport.update({
   id: '/waitlist',
   path: '/waitlist',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ContactUsRoute = ContactUsRouteImport.update({
+  id: '/contact-us',
+  path: '/contact-us',
   getParentRoute: () => rootRouteImport,
 } as any)
 const _authenticationLayoutRoute = _authenticationLayoutRouteImport.update({
@@ -63,6 +69,7 @@ const _authenticatedLayoutChatRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
+  '/contact-us': typeof ContactUsRoute
   '/waitlist': typeof WaitlistRoute
   '/chat': typeof _authenticatedLayoutChatRoute
   '/home': typeof _authenticatedLayoutHomeRoute
@@ -71,6 +78,7 @@ export interface FileRoutesByFullPath {
   '/': typeof _authenticatedLayoutIndexRoute
 }
 export interface FileRoutesByTo {
+  '/contact-us': typeof ContactUsRoute
   '/waitlist': typeof WaitlistRoute
   '/chat': typeof _authenticatedLayoutChatRoute
   '/home': typeof _authenticatedLayoutHomeRoute
@@ -82,6 +90,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/__authenticatedLayout': typeof _authenticatedLayoutRouteWithChildren
   '/__authenticationLayout': typeof _authenticationLayoutRouteWithChildren
+  '/contact-us': typeof ContactUsRoute
   '/waitlist': typeof WaitlistRoute
   '/__authenticatedLayout/chat': typeof _authenticatedLayoutChatRoute
   '/__authenticatedLayout/home': typeof _authenticatedLayoutHomeRoute
@@ -91,13 +100,28 @@ export interface FileRoutesById {
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/waitlist' | '/chat' | '/home' | '/login' | '/register' | '/'
+  fullPaths:
+    | '/contact-us'
+    | '/waitlist'
+    | '/chat'
+    | '/home'
+    | '/login'
+    | '/register'
+    | '/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/waitlist' | '/chat' | '/home' | '/login' | '/register' | '/'
+  to:
+    | '/contact-us'
+    | '/waitlist'
+    | '/chat'
+    | '/home'
+    | '/login'
+    | '/register'
+    | '/'
   id:
     | '__root__'
     | '/__authenticatedLayout'
     | '/__authenticationLayout'
+    | '/contact-us'
     | '/waitlist'
     | '/__authenticatedLayout/chat'
     | '/__authenticatedLayout/home'
@@ -109,6 +133,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   _authenticatedLayoutRoute: typeof _authenticatedLayoutRouteWithChildren
   _authenticationLayoutRoute: typeof _authenticationLayoutRouteWithChildren
+  ContactUsRoute: typeof ContactUsRoute
   WaitlistRoute: typeof WaitlistRoute
 }
 
@@ -119,6 +144,13 @@ declare module '@tanstack/react-router' {
       path: '/waitlist'
       fullPath: '/waitlist'
       preLoaderRoute: typeof WaitlistRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/contact-us': {
+      id: '/contact-us'
+      path: '/contact-us'
+      fullPath: '/contact-us'
+      preLoaderRoute: typeof ContactUsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/__authenticationLayout': {
@@ -206,6 +238,7 @@ const _authenticationLayoutRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   _authenticatedLayoutRoute: _authenticatedLayoutRouteWithChildren,
   _authenticationLayoutRoute: _authenticationLayoutRouteWithChildren,
+  ContactUsRoute: ContactUsRoute,
   WaitlistRoute: WaitlistRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/contact-us.tsx
+++ b/src/routes/contact-us.tsx
@@ -1,0 +1,58 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { createFileRoute } from "@tanstack/react-router";
+import { useTranslate } from "@tolgee/react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+export const Route = createFileRoute("/contact-us")({
+  component: ContactUsPage,
+});
+
+function ContactUsPage() {
+  const { t } = useTranslate();
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    toast.success(t("contact.success"));
+    setEmail("");
+    setMessage("");
+  };
+
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center bg-muted px-4 py-10">
+      <div className="w-full max-w-md">
+        <div className="flex flex-col items-center gap-6 text-center">
+          <img
+            src="/assets/mascot/mascot_detective.png"
+            alt={t("contact.title")}
+            className="w-40"
+          />
+          <h1 className="text-3xl font-bold">{t("contact.title")}</h1>
+          <p className="text-muted-foreground">{t("contact.description")}</p>
+          <form onSubmit={handleSubmit} className="flex w-full flex-col gap-4">
+            <Input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder={t("contact.emailPlaceholder")}
+            />
+            <textarea
+              required
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder={t("contact.messagePlaceholder")}
+              className="min-h-32 rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            />
+            <Button type="submit" className="w-full">
+              {t("contact.submit")}
+            </Button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -56,6 +56,16 @@
     "submit": "Join waitlist",
     "success": "Thanks! We'll be in touch."
   },
+  "contact": {
+    "title": "Contact Us",
+    "description": "Have questions? We're here to help.",
+    "email": "Email",
+    "emailPlaceholder": "Write your email...",
+    "message": "Message",
+    "messagePlaceholder": "Write your message...",
+    "submit": "Send message",
+    "success": "Thanks! We'll get back to you."
+  },
   "soon": "Soon",
   "validation": {
     "invalidEmail": "Invalid email",

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -56,6 +56,16 @@
     "submit": "Entrar na lista",
     "success": "Obrigado! Entraremos em contato."
   },
+  "contact": {
+    "title": "Fale Conosco",
+    "description": "Tem perguntas? Estamos aqui para ajudar.",
+    "email": "Email",
+    "emailPlaceholder": "Digite seu email...",
+    "message": "Mensagem",
+    "messagePlaceholder": "Digite sua mensagem...",
+    "submit": "Enviar mensagem",
+    "success": "Obrigado! Entraremos em contato."
+  },
   "soon": "Em breve",
   "validation": {
     "invalidEmail": "Email inválido",


### PR DESCRIPTION
## Summary
- add Contact Us route with mascot image and form
- localize contact page content in English and Portuguese

## Testing
- `pnpm build`
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a010c3bdb0832eb592e9fa112e8ea2