### PR TITLE
feat: add Cherry Bomb One font for login branding

### DIFF
--- a/src/routes/__authenticationLayout/login.tsx
+++ b/src/routes/__authenticationLayout/login.tsx
@@ -78,7 +78,7 @@ function RouteComponent() {
                   className="w-60 object-contain"
                 />
                 <div className="absolute bottom-4 text-center">
-                  <h2 className="text-3xl font-bold text-orange-500 drop-shadow-md">
+                  <h2 className="font-cherry text-3xl font-bold text-orange-500 drop-shadow-md">
                     {t("login.appName")}
                   </h2>
                   <p className="text-sm text-muted-foreground">

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Cherry+Bomb+One&display=swap");
 @import "tailwindcss";
 
 @import "tw-animate-css";
@@ -90,6 +91,7 @@ code {
 }
 
 @theme inline {
+  --font-cherry: "Cherry Bomb One", cursive;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);


### PR DESCRIPTION
## Summary
- import Cherry Bomb One from Google Fonts and expose `font-cherry` utility
- style login page app name with the new font

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a096b90d5c832eaedb9c8fa2537699