### PR TITLE
Add contact page and drawer

### DIFF
--- a/src/components/contact-drawer.tsx
+++ b/src/components/contact-drawer.tsx
@@ -1,21 +1,6 @@
 import { useState } from "react";
-import { useTranslate } from "@tolgee/react";
-import { toast } from "sonner";
-import { useForm } from "react-hook-form";
-import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
-
+import { ContactForm } from "@/components/contact-form";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
 import {
   Drawer,
   DrawerTrigger,
@@ -24,31 +9,11 @@ import {
   DrawerTitle,
   DrawerDescription,
 } from "@/components/ui/drawer";
+import { useTranslate } from "@tolgee/react";
 
 export function ContactDrawer() {
   const { t } = useTranslate();
   const [open, setOpen] = useState(false);
-
-  const formSchema = z.object({
-    email: z
-      .string()
-      .nonempty({ message: t("validation.required") })
-      .email({ message: t("validation.invalidEmail") }),
-    message: z.string().nonempty({ message: t("validation.required") }),
-  });
-
-  type FormValues = z.infer<typeof formSchema>;
-
-  const formMethods = useForm<FormValues>({
-    resolver: zodResolver(formSchema),
-    defaultValues: { email: "", message: "" },
-  });
-
-  const onSubmit = () => {
-    toast.success(t("contact.success"));
-    formMethods.reset();
-    setOpen(false);
-  };
 
   return (
     <Drawer open={open} onOpenChange={setOpen}>
@@ -65,47 +30,7 @@ export function ContactDrawer() {
           <DrawerTitle>{t("contact.title")}</DrawerTitle>
           <DrawerDescription>{t("contact.description")}</DrawerDescription>
         </DrawerHeader>
-        <Form {...formMethods}>
-          <form onSubmit={formMethods.handleSubmit(onSubmit)} className="flex flex-col gap-4 p-4">
-            <FormField
-              control={formMethods.control}
-              name="email"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t("contact.email")}</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="email"
-                      placeholder={t("contact.emailPlaceholder")}
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={formMethods.control}
-              name="message"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t("contact.message")}</FormLabel>
-                  <FormControl>
-                    <Textarea
-                      placeholder={t("contact.messagePlaceholder")}
-                      className="min-h-[120px]"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <Button type="submit" className="w-full">
-              {t("contact.submit")}
-            </Button>
-          </form>
-        </Form>
+        <ContactForm className="p-4" onSubmitted={() => setOpen(false)} />
       </DrawerContent>
     </Drawer>
   );

--- a/src/components/contact-drawer.tsx
+++ b/src/components/contact-drawer.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import { useTranslate } from "@tolgee/react";
+import { toast } from "sonner";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Drawer,
+  DrawerTrigger,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+} from "@/components/ui/drawer";
+
+export function ContactDrawer() {
+  const { t } = useTranslate();
+  const [open, setOpen] = useState(false);
+
+  const formSchema = z.object({
+    email: z
+      .string()
+      .nonempty({ message: t("validation.required") })
+      .email({ message: t("validation.invalidEmail") }),
+    message: z.string().nonempty({ message: t("validation.required") }),
+  });
+
+  type FormValues = z.infer<typeof formSchema>;
+
+  const formMethods = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { email: "", message: "" },
+  });
+
+  const onSubmit = () => {
+    toast.success(t("contact.success"));
+    formMethods.reset();
+    setOpen(false);
+  };
+
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <DrawerTrigger asChild>
+        <Button>{t("contact.title")}</Button>
+      </DrawerTrigger>
+      <DrawerContent className="h-[80vh]">
+        <img
+          src="/assets/mascot/mascot_detective.png"
+          alt="Cat mascot"
+          className="mx-auto my-4 h-40 w-auto"
+        />
+        <DrawerHeader>
+          <DrawerTitle>{t("contact.title")}</DrawerTitle>
+          <DrawerDescription>{t("contact.description")}</DrawerDescription>
+        </DrawerHeader>
+        <Form {...formMethods}>
+          <form onSubmit={formMethods.handleSubmit(onSubmit)} className="flex flex-col gap-4 p-4">
+            <FormField
+              control={formMethods.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("contact.email")}</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder={t("contact.emailPlaceholder")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={formMethods.control}
+              name="message"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("contact.message")}</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={t("contact.messagePlaceholder")}
+                      className="min-h-[120px]"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button type="submit" className="w-full">
+              {t("contact.submit")}
+            </Button>
+          </form>
+        </Form>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -1,0 +1,94 @@
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTranslate } from "@tolgee/react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+interface ContactFormProps {
+  className?: string;
+  onSubmitted?: () => void;
+}
+
+export function ContactForm({ className, onSubmitted }: ContactFormProps) {
+  const { t } = useTranslate();
+
+  const formSchema = z.object({
+    email: z
+      .string()
+      .nonempty({ message: t("validation.required") })
+      .email({ message: t("validation.invalidEmail") }),
+    message: z.string().nonempty({ message: t("validation.required") }),
+  });
+
+  type FormValues = z.infer<typeof formSchema>;
+
+  const formMethods = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { email: "", message: "" },
+  });
+
+  const onSubmit = () => {
+    toast.success(t("contact.success"));
+    formMethods.reset();
+    onSubmitted?.();
+  };
+
+  return (
+    <Form {...formMethods}>
+      <form
+        onSubmit={formMethods.handleSubmit(onSubmit)}
+        className={cn("flex flex-col gap-4", className)}
+      >
+        <FormField
+          control={formMethods.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("contact.email")}</FormLabel>
+              <FormControl>
+                <Input
+                  type="email"
+                  placeholder={t("contact.emailPlaceholder")}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={formMethods.control}
+          name="message"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("contact.message")}</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder={t("contact.messagePlaceholder")}
+                  className="min-h-[120px]"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="w-full">
+          {t("contact.submit")}
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex min-h-[80px] w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WaitlistDrawerTestRouteImport } from './routes/waitlist-drawer-test'
 import { Route as WaitlistRouteImport } from './routes/waitlist'
+import { Route as ContactRouteImport } from './routes/contact'
 import { Route as _authenticationLayoutRouteImport } from './routes/__authenticationLayout'
 import { Route as _authenticatedLayoutRouteImport } from './routes/__authenticatedLayout'
 import { Route as _authenticatedLayoutIndexRouteImport } from './routes/__authenticatedLayout/index'
@@ -27,6 +28,11 @@ const WaitlistDrawerTestRoute = WaitlistDrawerTestRouteImport.update({
 const WaitlistRoute = WaitlistRouteImport.update({
   id: '/waitlist',
   path: '/waitlist',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ContactRoute = ContactRouteImport.update({
+  id: '/contact',
+  path: '/contact',
   getParentRoute: () => rootRouteImport,
 } as any)
 const _authenticationLayoutRoute = _authenticationLayoutRouteImport.update({
@@ -69,6 +75,7 @@ const _authenticatedLayoutChatRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
+  '/contact': typeof ContactRoute
   '/waitlist': typeof WaitlistRoute
   '/waitlist-drawer-test': typeof WaitlistDrawerTestRoute
   '/chat': typeof _authenticatedLayoutChatRoute
@@ -78,6 +85,7 @@ export interface FileRoutesByFullPath {
   '/': typeof _authenticatedLayoutIndexRoute
 }
 export interface FileRoutesByTo {
+  '/contact': typeof ContactRoute
   '/waitlist': typeof WaitlistRoute
   '/waitlist-drawer-test': typeof WaitlistDrawerTestRoute
   '/chat': typeof _authenticatedLayoutChatRoute
@@ -90,6 +98,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/__authenticatedLayout': typeof _authenticatedLayoutRouteWithChildren
   '/__authenticationLayout': typeof _authenticationLayoutRouteWithChildren
+  '/contact': typeof ContactRoute
   '/waitlist': typeof WaitlistRoute
   '/waitlist-drawer-test': typeof WaitlistDrawerTestRoute
   '/__authenticatedLayout/chat': typeof _authenticatedLayoutChatRoute
@@ -101,6 +110,7 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/contact'
     | '/waitlist'
     | '/waitlist-drawer-test'
     | '/chat'
@@ -110,6 +120,7 @@ export interface FileRouteTypes {
     | '/'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | '/contact'
     | '/waitlist'
     | '/waitlist-drawer-test'
     | '/chat'
@@ -121,6 +132,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/__authenticatedLayout'
     | '/__authenticationLayout'
+    | '/contact'
     | '/waitlist'
     | '/waitlist-drawer-test'
     | '/__authenticatedLayout/chat'
@@ -133,6 +145,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   _authenticatedLayoutRoute: typeof _authenticatedLayoutRouteWithChildren
   _authenticationLayoutRoute: typeof _authenticationLayoutRouteWithChildren
+  ContactRoute: typeof ContactRoute
   WaitlistRoute: typeof WaitlistRoute
   WaitlistDrawerTestRoute: typeof WaitlistDrawerTestRoute
 }
@@ -151,6 +164,13 @@ declare module '@tanstack/react-router' {
       path: '/waitlist'
       fullPath: '/waitlist'
       preLoaderRoute: typeof WaitlistRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/contact': {
+      id: '/contact'
+      path: '/contact'
+      fullPath: '/contact'
+      preLoaderRoute: typeof ContactRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/__authenticationLayout': {
@@ -238,6 +258,7 @@ const _authenticationLayoutRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   _authenticatedLayoutRoute: _authenticatedLayoutRouteWithChildren,
   _authenticationLayoutRoute: _authenticationLayoutRouteWithChildren,
+  ContactRoute: ContactRoute,
   WaitlistRoute: WaitlistRoute,
   WaitlistDrawerTestRoute: WaitlistDrawerTestRoute,
 }

--- a/src/routes/contact.tsx
+++ b/src/routes/contact.tsx
@@ -1,20 +1,6 @@
-import { Button } from "@/components/ui/button";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
+import { ContactForm } from "@/components/contact-form";
 import { createFileRoute } from "@tanstack/react-router";
 import { useTranslate } from "@tolgee/react";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
-import { toast } from "sonner";
 
 export const Route = createFileRoute("/contact")({
   component: ContactPage,
@@ -22,29 +8,6 @@ export const Route = createFileRoute("/contact")({
 
 function ContactPage() {
   const { t } = useTranslate();
-
-  const formSchema = z.object({
-    email: z
-      .string()
-      .nonempty({ message: t("validation.required") })
-      .email({ message: t("validation.invalidEmail") }),
-    message: z.string().nonempty({ message: t("validation.required") }),
-  });
-
-  type FormValues = z.infer<typeof formSchema>;
-
-  const formMethods = useForm<FormValues>({
-    resolver: zodResolver(formSchema),
-    defaultValues: {
-      email: "",
-      message: "",
-    },
-  });
-
-  const onSubmit = () => {
-    toast.success(t("contact.success"));
-    formMethods.reset();
-  };
 
   return (
     <div className="flex min-h-dvh flex-col items-center justify-center bg-muted px-4 py-10">
@@ -57,50 +20,7 @@ function ContactPage() {
           />
           <h1 className="text-3xl font-bold">{t("contact.title")}</h1>
           <p className="text-muted-foreground">{t("contact.description")}</p>
-          <Form {...formMethods}>
-            <form
-              onSubmit={formMethods.handleSubmit(onSubmit)}
-              className="flex w-full flex-col gap-4"
-            >
-              <FormField
-                control={formMethods.control}
-                name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t("contact.email")}</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="email"
-                        placeholder={t("contact.emailPlaceholder")}
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={formMethods.control}
-                name="message"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t("contact.message")}</FormLabel>
-                    <FormControl>
-                      <Textarea
-                        placeholder={t("contact.messagePlaceholder")}
-                        className="min-h-[120px]"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <Button type="submit" className="w-full">
-                {t("contact.submit")}
-              </Button>
-            </form>
-          </Form>
+          <ContactForm className="w-full" />
         </div>
       </div>
     </div>

--- a/src/routes/contact.tsx
+++ b/src/routes/contact.tsx
@@ -1,0 +1,108 @@
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { createFileRoute } from "@tanstack/react-router";
+import { useTranslate } from "@tolgee/react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+
+export const Route = createFileRoute("/contact")({
+  component: ContactPage,
+});
+
+function ContactPage() {
+  const { t } = useTranslate();
+
+  const formSchema = z.object({
+    email: z
+      .string()
+      .nonempty({ message: t("validation.required") })
+      .email({ message: t("validation.invalidEmail") }),
+    message: z.string().nonempty({ message: t("validation.required") }),
+  });
+
+  type FormValues = z.infer<typeof formSchema>;
+
+  const formMethods = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      email: "",
+      message: "",
+    },
+  });
+
+  const onSubmit = () => {
+    toast.success(t("contact.success"));
+    formMethods.reset();
+  };
+
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-muted px-4 py-10">
+      <div className="w-full max-w-md">
+        <div className="flex flex-col items-center gap-6 text-center">
+          <img
+            src="/assets/mascot/mascot_detective.png"
+            alt={t("contact.title")}
+            className="w-40"
+          />
+          <h1 className="text-3xl font-bold">{t("contact.title")}</h1>
+          <p className="text-muted-foreground">{t("contact.description")}</p>
+          <Form {...formMethods}>
+            <form
+              onSubmit={formMethods.handleSubmit(onSubmit)}
+              className="flex w-full flex-col gap-4"
+            >
+              <FormField
+                control={formMethods.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("contact.email")}</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="email"
+                        placeholder={t("contact.emailPlaceholder")}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={formMethods.control}
+                name="message"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("contact.message")}</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder={t("contact.messagePlaceholder")}
+                        className="min-h-[120px]"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Button type="submit" className="w-full">
+                {t("contact.submit")}
+              </Button>
+            </form>
+          </Form>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add contact us page using react-hook-form and zod validation
- create reusable contact drawer component
- introduce textarea UI component

## Testing
- `pnpm build`
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a096985c10832e842a2cb01c39a1df