### PR TITLE
feat: open contact drawer from support sidebar item

### DIFF
--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { Calendar, Command, LifeBuoy, Send, Bot } from "lucide-react";
 
+import { ContactDrawer } from "@/components/contact-drawer";
+
 import { NavMain } from "@/components/sidebar/nav-main";
 import { NavSecondary } from "@/components/sidebar/nav-secondary";
 import { NavUser } from "@/components/sidebar/nav-user";
@@ -41,8 +43,15 @@ const data = {
   navSecondary: [
     {
       title: "Support",
-      url: "#",
       icon: LifeBuoy,
+      render: (item) => (
+        <ContactDrawer>
+          <SidebarMenuButton size="sm">
+            <item.icon />
+            <span>{item.title}</span>
+          </SidebarMenuButton>
+        </ContactDrawer>
+      ),
     },
     {
       title: "Feedback",

--- a/src/components/sidebar/nav-secondary.tsx
+++ b/src/components/sidebar/nav-secondary.tsx
@@ -16,8 +16,9 @@ export function NavSecondary({
 }: {
   items: {
     title: string;
-    url: string;
     icon: LucideIcon;
+    url?: string;
+    render?: (item: { title: string; icon: LucideIcon }) => React.ReactNode;
   }[];
 } & React.ComponentPropsWithoutRef<typeof SidebarGroup>) {
   return (
@@ -26,12 +27,16 @@ export function NavSecondary({
         <SidebarMenu>
           {items.map((item) => (
             <SidebarMenuItem key={item.title}>
-              <SidebarMenuButton asChild size="sm">
-                <Link to={item.url}>
-                  <item.icon />
-                  <span>{item.title}</span>
-                </Link>
-              </SidebarMenuButton>
+              {item.render ? (
+                item.render(item)
+              ) : (
+                <SidebarMenuButton asChild size="sm">
+                  <Link to={item.url!}>
+                    <item.icon />
+                    <span>{item.title}</span>
+                  </Link>
+                </SidebarMenuButton>
+              )}
             </SidebarMenuItem>
           ))}
         </SidebarMenu>


### PR DESCRIPTION
## Summary
- allow NavSecondary to render custom elements
- trigger contact drawer when selecting Support in the sidebar

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09cd7413c832eae04e68718dac009