### PR TITLE
feat: integrate vanish input into chat

### DIFF
--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -3,7 +3,8 @@ import { useChat } from "@ai-sdk/react";
 import { Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { PlaceholdersAndVanishInput } from "@/components/ui/placeholders-and-vanish-input";
+import { toast } from "sonner";
 import { OpenAIChatTransport } from "@/lib/openai-chat-transport";
 
 export function Chat() {
@@ -19,11 +20,22 @@ export function Chat() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!input.trim()) return;
-    await sendMessage({
-      role: "user",
-      parts: [{ type: "text", text: input }],
-    });
-    setInput("");
+    try {
+      await toast.promise(
+        sendMessage({
+          role: "user",
+          parts: [{ type: "text", text: input }],
+        }),
+        {
+          loading: "Sending message...",
+          success: "Message sent",
+          error: "Failed to send message",
+        }
+      );
+      setInput("");
+    } catch (error) {
+      // error handled by toast.promise
+    }
   }
 
   const isLoading = status !== "ready";
@@ -60,10 +72,14 @@ export function Chat() {
         onSubmit={handleSubmit}
         className="flex gap-2 border-t bg-background p-4"
       >
-        <Input
+        <PlaceholdersAndVanishInput
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          placeholder="Type your message"
+          placeholders={[
+            "Type your message",
+            "Ask me anything",
+            "Need help with something?",
+          ]}
           className="flex-1"
         />
         <Button type="submit" disabled={isLoading || !input.trim()}>

--- a/src/components/ui/placeholders-and-vanish-input.tsx
+++ b/src/components/ui/placeholders-and-vanish-input.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { Input } from "./input";
+
+interface PlaceholdersAndVanishInputProps
+  extends React.ComponentProps<typeof Input> {
+  placeholders: string[];
+}
+
+export function PlaceholdersAndVanishInput({
+  placeholders,
+  className,
+  value,
+  ...props
+}: PlaceholdersAndVanishInputProps) {
+  const [index, setIndex] = useState(0);
+  const [vanish, setVanish] = useState(false);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setVanish(true);
+      const timeout = setTimeout(() => {
+        setIndex((i) => (i + 1) % placeholders.length);
+        setVanish(false);
+      }, 500);
+      return () => clearTimeout(timeout);
+    }, 2000);
+    return () => clearInterval(interval);
+  }, [placeholders.length]);
+
+  const showPlaceholder =
+    typeof value === "string" ? value.length === 0 : !value;
+
+  return (
+    <div className="relative w-full">
+      <Input {...props} value={value} className={cn("peer", className)} />
+      {showPlaceholder && (
+        <span
+          className={cn(
+            "pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground transition-opacity duration-500 peer-focus:opacity-0",
+            vanish ? "opacity-0" : "opacity-100"
+          )}
+        >
+          {placeholders[index]}
+        </span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholders-and-vanish input component
- switch chat box to new animated input and toast feedback

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c6a7dd74832e9d039b15f41d4905