### PR TITLE
feat: add feedback credenza and page

### DIFF
--- a/src/components/feedback-credenza.tsx
+++ b/src/components/feedback-credenza.tsx
@@ -1,0 +1,41 @@
+import { FeedbackForm } from "@/components/feedback-form";
+import { Button } from "@/components/ui/button";
+import {
+  Credenza,
+  CredenzaBody,
+  CredenzaContent,
+  CredenzaDescription,
+  CredenzaHeader,
+  CredenzaTitle,
+  CredenzaTrigger,
+} from "@/components/ui/credenza";
+import { useTranslate } from "@tolgee/react";
+import { useState } from "react";
+
+export function FeedbackCredenza({ children }: { children?: React.ReactNode }) {
+  const { t } = useTranslate();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Credenza open={open} onOpenChange={setOpen}>
+      <CredenzaTrigger asChild>
+        {children ?? <Button>{t("feedback.title")}</Button>}
+      </CredenzaTrigger>
+      <CredenzaContent>
+        <img
+          src="/assets/mascot/mascot_full_body.png"
+          alt="Cat mascot"
+          className="mx-auto my-4 h-40 w-auto"
+        />
+        <CredenzaHeader>
+          <CredenzaTitle>{t("feedback.title")}</CredenzaTitle>
+          <CredenzaDescription>{t("feedback.description")}</CredenzaDescription>
+        </CredenzaHeader>
+        <CredenzaBody className="pb-4">
+          <FeedbackForm onSubmitted={() => setOpen(false)} />
+        </CredenzaBody>
+      </CredenzaContent>
+    </Credenza>
+  );
+}
+

--- a/src/components/feedback-form.tsx
+++ b/src/components/feedback-form.tsx
@@ -1,0 +1,95 @@
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTranslate } from "@tolgee/react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+interface FeedbackFormProps {
+  className?: string;
+  onSubmitted?: () => void;
+}
+
+export function FeedbackForm({ className, onSubmitted }: FeedbackFormProps) {
+  const { t } = useTranslate();
+
+  const formSchema = z.object({
+    email: z
+      .string()
+      .nonempty({ message: t("validation.required") })
+      .email({ message: t("validation.invalidEmail") }),
+    message: z.string().nonempty({ message: t("validation.required") }),
+  });
+
+  type FormValues = z.infer<typeof formSchema>;
+
+  const formMethods = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { email: "", message: "" },
+  });
+
+  const onSubmit = () => {
+    toast.success(t("feedback.success"));
+    formMethods.reset();
+    onSubmitted?.();
+  };
+
+  return (
+    <Form {...formMethods}>
+      <form
+        onSubmit={formMethods.handleSubmit(onSubmit)}
+        className={cn("flex flex-col gap-4", className)}
+      >
+        <FormField
+          control={formMethods.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("feedback.email")}</FormLabel>
+              <FormControl>
+                <Input
+                  type="email"
+                  placeholder={t("feedback.emailPlaceholder")}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={formMethods.control}
+          name="message"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("feedback.message")}</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder={t("feedback.messagePlaceholder")}
+                  className="min-h-[120px]"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="w-full">
+          {t("feedback.submit")}
+        </Button>
+      </form>
+    </Form>
+  );
+}
+

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 
 import { ContactCredenza } from "@/components/contact-credenza";
+import { FeedbackCredenza } from "@/components/feedback-credenza";
 
 import { NavMain } from "@/components/sidebar/nav-main";
 import { NavSecondary } from "@/components/sidebar/nav-secondary";
@@ -62,8 +63,15 @@ const data = {
     },
     {
       title: "Feedback",
-      url: "#",
       icon: Send,
+      render: (item: { title: string; icon: LucideIcon }) => (
+        <FeedbackCredenza>
+          <SidebarMenuButton size="sm">
+            <item.icon />
+            <span>{item.title}</span>
+          </SidebarMenuButton>
+        </FeedbackCredenza>
+      ),
     },
   ],
   projects: [],

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WaitlistDrawerTestRouteImport } from './routes/waitlist-drawer-test'
 import { Route as WaitlistRouteImport } from './routes/waitlist'
+import { Route as FeedbackRouteImport } from './routes/feedback'
 import { Route as ContactRouteImport } from './routes/contact'
 import { Route as _authenticationLayoutRouteImport } from './routes/__authenticationLayout'
 import { Route as _authenticatedLayoutRouteImport } from './routes/__authenticatedLayout'
@@ -28,6 +29,11 @@ const WaitlistDrawerTestRoute = WaitlistDrawerTestRouteImport.update({
 const WaitlistRoute = WaitlistRouteImport.update({
   id: '/waitlist',
   path: '/waitlist',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FeedbackRoute = FeedbackRouteImport.update({
+  id: '/feedback',
+  path: '/feedback',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ContactRoute = ContactRouteImport.update({
@@ -76,6 +82,7 @@ const _authenticatedLayoutChatRoute =
 
 export interface FileRoutesByFullPath {
   '/contact': typeof ContactRoute
+  '/feedback': typeof FeedbackRoute
   '/waitlist': typeof WaitlistRoute
   '/waitlist-drawer-test': typeof WaitlistDrawerTestRoute
   '/chat': typeof _authenticatedLayoutChatRoute
@@ -86,6 +93,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/contact': typeof ContactRoute
+  '/feedback': typeof FeedbackRoute
   '/waitlist': typeof WaitlistRoute
   '/waitlist-drawer-test': typeof WaitlistDrawerTestRoute
   '/chat': typeof _authenticatedLayoutChatRoute
@@ -99,6 +107,7 @@ export interface FileRoutesById {
   '/__authenticatedLayout': typeof _authenticatedLayoutRouteWithChildren
   '/__authenticationLayout': typeof _authenticationLayoutRouteWithChildren
   '/contact': typeof ContactRoute
+  '/feedback': typeof FeedbackRoute
   '/waitlist': typeof WaitlistRoute
   '/waitlist-drawer-test': typeof WaitlistDrawerTestRoute
   '/__authenticatedLayout/chat': typeof _authenticatedLayoutChatRoute
@@ -111,6 +120,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/contact'
+    | '/feedback'
     | '/waitlist'
     | '/waitlist-drawer-test'
     | '/chat'
@@ -121,6 +131,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/contact'
+    | '/feedback'
     | '/waitlist'
     | '/waitlist-drawer-test'
     | '/chat'
@@ -133,6 +144,7 @@ export interface FileRouteTypes {
     | '/__authenticatedLayout'
     | '/__authenticationLayout'
     | '/contact'
+    | '/feedback'
     | '/waitlist'
     | '/waitlist-drawer-test'
     | '/__authenticatedLayout/chat'
@@ -146,6 +158,7 @@ export interface RootRouteChildren {
   _authenticatedLayoutRoute: typeof _authenticatedLayoutRouteWithChildren
   _authenticationLayoutRoute: typeof _authenticationLayoutRouteWithChildren
   ContactRoute: typeof ContactRoute
+  FeedbackRoute: typeof FeedbackRoute
   WaitlistRoute: typeof WaitlistRoute
   WaitlistDrawerTestRoute: typeof WaitlistDrawerTestRoute
 }
@@ -164,6 +177,13 @@ declare module '@tanstack/react-router' {
       path: '/waitlist'
       fullPath: '/waitlist'
       preLoaderRoute: typeof WaitlistRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/feedback': {
+      id: '/feedback'
+      path: '/feedback'
+      fullPath: '/feedback'
+      preLoaderRoute: typeof FeedbackRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/contact': {
@@ -259,6 +279,7 @@ const rootRouteChildren: RootRouteChildren = {
   _authenticatedLayoutRoute: _authenticatedLayoutRouteWithChildren,
   _authenticationLayoutRoute: _authenticationLayoutRouteWithChildren,
   ContactRoute: ContactRoute,
+  FeedbackRoute: FeedbackRoute,
   WaitlistRoute: WaitlistRoute,
   WaitlistDrawerTestRoute: WaitlistDrawerTestRoute,
 }

--- a/src/routes/feedback.tsx
+++ b/src/routes/feedback.tsx
@@ -1,0 +1,29 @@
+import { FeedbackForm } from "@/components/feedback-form";
+import { createFileRoute } from "@tanstack/react-router";
+import { useTranslate } from "@tolgee/react";
+
+export const Route = createFileRoute("/feedback")({
+  component: FeedbackPage,
+});
+
+function FeedbackPage() {
+  const { t } = useTranslate();
+
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-muted px-4 py-10">
+      <div className="w-full max-w-md">
+        <div className="flex flex-col items-center gap-6 text-center">
+          <img
+            src="/assets/mascot/mascot_full_body.png"
+            alt={t("feedback.title")}
+            className="w-40"
+          />
+          <h1 className="text-3xl font-bold">{t("feedback.title")}</h1>
+          <p className="text-muted-foreground">{t("feedback.description")}</p>
+          <FeedbackForm className="w-full" />
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8,7 +8,15 @@
       "funMessage": "Don't worry, our chef cat is always cooking up something delicious! \uD83C\uDF7D️",
       "logoAlt": "Food Calendar Track",
       "title": "Oops! Page Not Found"
-    }
+    },
+    "title": "Send Feedback",
+    "description": "Share your thoughts with us.",
+    "email": "Email",
+    "emailPlaceholder": "Write your email...",
+    "message": "Message",
+    "messagePlaceholder": "Write your feedback...",
+    "submit": "Send feedback",
+    "success": "Thanks for your feedback!"
   },
   "login": {
     "agreeTo": "By clicking continue, you agree to our",

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -8,7 +8,15 @@
       "funMessage": "Não se preocupe, nosso gato chef está sempre preparando algo delicioso! \uD83C\uDF7D️",
       "logoAlt": "Calendário de Refeições",
       "title": "Ops! Página não encontrada"
-    }
+    },
+    "title": "Enviar feedback",
+    "description": "Compartilhe suas ideias conosco.",
+    "email": "Email",
+    "emailPlaceholder": "Digite seu email...",
+    "message": "Mensagem",
+    "messagePlaceholder": "Digite seu feedback...",
+    "submit": "Enviar feedback",
+    "success": "Obrigado pelo feedback!"
   },
   "login": {
     "agreeTo": "Ao clicar em continuar, você concorda com nossos",


### PR DESCRIPTION
## Summary
- add feedback form component and credenza
- expose feedback form on dedicated page and sidebar button
- localize feedback strings

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d22bc5f0832e89821a287ba26c6e