### PR TITLE
Improve chat scrollbar styling

### DIFF
--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -38,7 +38,7 @@ export function ChatMessages({ messages, isLoading }: ChatMessagesProps) {
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="flex h-full flex-col space-y-4 overflow-y-auto overflow-x-hidden py-4"
+        className="chat-scrollbar flex h-full flex-col space-y-4 overflow-y-auto overflow-x-hidden py-4"
       >
         {messages.map((m) => (
           <ChatBubble key={m.id} role={m.role}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -142,3 +142,32 @@ code {
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .chat-scrollbar {
+    scrollbar-width: none;
+  }
+  .chat-scrollbar:hover,
+  .chat-scrollbar:focus {
+    scrollbar-width: thin;
+    scrollbar-color: var(--primary) var(--muted);
+  }
+  .chat-scrollbar::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+  .chat-scrollbar:hover::-webkit-scrollbar,
+  .chat-scrollbar:focus::-webkit-scrollbar {
+    width: 4px;
+    height: 4px;
+  }
+  .chat-scrollbar:hover::-webkit-scrollbar-track,
+  .chat-scrollbar:focus::-webkit-scrollbar-track {
+    background-color: var(--muted);
+  }
+  .chat-scrollbar:hover::-webkit-scrollbar-thumb,
+  .chat-scrollbar:focus::-webkit-scrollbar-thumb {
+    background-color: var(--primary);
+    border-radius: 9999px;
+  }
+}


### PR DESCRIPTION
## Summary
- add `chat-scrollbar` utility for a thin, theme-colored scrollbar that hides until interacted with
- apply `chat-scrollbar` to chat messages container

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dd541848832e9c8c5ca73a9a089e