### PR TITLE
fix: enable chat scroll

### DIFF
--- a/src/routes/__authenticatedLayout.tsx
+++ b/src/routes/__authenticatedLayout.tsx
@@ -54,7 +54,8 @@ function RouteComponent() {
   return (
     <SidebarProvider>
       <AppSidebar />
-      <SidebarInset className="min-h-0 overflow-hidden">
+      {/* Allow the main content area to scroll when necessary */}
+      <SidebarInset className="min-h-0 overflow-x-hidden overflow-y-auto">
         <header className="flex h-16 shrink-0 items-center gap-2">
           <div className="flex items-center gap-2 px-4">
             <SidebarTrigger className="-ml-1" />
@@ -63,7 +64,7 @@ function RouteComponent() {
             <ModeToggle />
           </div>
         </header>
-        <div className="flex flex-1 min-h-0 flex-col gap-4 p-4 pt-0 overflow-hidden">
+        <div className="flex flex-1 min-h-0 flex-col gap-4 p-4 pt-0 overflow-x-hidden overflow-y-auto">
           <Outlet />
         </div>
       </SidebarInset>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -23,7 +23,8 @@ function RootComponent() {
   const { queryClient } = Route.useLoaderData();
   return (
     <QueryClientProvider client={queryClient}>
-      <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
+      {/* Allow nested routes to scroll vertically when content overflows */}
+      <div className="flex flex-1 min-h-0 flex-col overflow-x-hidden overflow-y-auto">
         <TanStackRouterDevtools position="top-right" />
         <Outlet />
         <Toaster position="top-center" offset={60} />

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,7 +6,8 @@
 @custom-variant dark (&:is(.dark *));
 
 body {
-  @apply m-0 h-dvh w-dvw overflow-hidden;
+  /* Allow pages to scroll vertically while preventing horizontal overflow */
+  @apply m-0 h-dvh w-dvw overflow-x-hidden overflow-y-auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
     "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
@@ -15,7 +16,8 @@ body {
 }
 
 #app {
-  @apply flex h-full w-full flex-col min-h-0 overflow-hidden;
+  /* Ensure the app container can scroll if its content overflows */
+  @apply flex h-full w-full flex-col min-h-0 overflow-x-hidden overflow-y-auto;
 }
 
 code {


### PR DESCRIPTION
## Summary
- allow vertical scrolling in global body and app container
- enable scrolling in root and authenticated layouts to keep chat usable

## Testing
- `pnpm test` *(fails: No test files found)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a0e69b3f84832e94500f7a392fb8e7