### PR TITLE
Add Vitest unit tests with mocked API and hooks

### DIFF
--- a/src/components/sidebar/nav-user.test.tsx
+++ b/src/components/sidebar/nav-user.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { NavUser } from './nav-user'
+
+vi.mock('@/hooks/queries/user', () => ({
+  default: () => ({ data: { name: 'John Doe', email: 'john@example.com' } }),
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: () => ({ mutate: vi.fn(), status: 'idle' }),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => () => {},
+}))
+
+vi.mock('@/lib/appwrite', () => ({
+  account: { deleteSession: vi.fn() },
+}))
+
+vi.mock('@/components/ui/sidebar', () => ({
+  useSidebar: () => ({ isMobile: false }),
+  SidebarMenu: ({ children }: any) => <div>{children}</div>,
+  SidebarMenuItem: ({ children }: any) => <div>{children}</div>,
+  SidebarMenuButton: ({ children }: any) => <button>{children}</button>,
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuLabel: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <div />,
+  DropdownMenuItem: ({ children }: any) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/avatar', () => ({
+  Avatar: ({ children }: any) => <div>{children}</div>,
+  AvatarImage: (props: any) => <img {...props} />,
+  AvatarFallback: ({ children }: any) => <div>{children}</div>,
+}))
+
+describe('NavUser', () => {
+  it('renders session user information', () => {
+    render(<NavUser />)
+    expect(screen.getAllByText('John Doe')[0]).toBeTruthy()
+    expect(screen.getAllByText('john@example.com')[0]).toBeTruthy()
+  })
+})

--- a/src/hooks/queries/user.test.tsx
+++ b/src/hooks/queries/user.test.tsx
@@ -1,0 +1,34 @@
+import { vi } from 'vitest'
+
+const { mockedGet } = vi.hoisted(() => ({
+  mockedGet: vi.fn(),
+}))
+
+vi.mock('@/lib/appwrite', () => ({
+  account: { get: mockedGet },
+}))
+
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect } from 'vitest'
+import useSession from './user'
+
+describe('useSession', () => {
+  it('fetches the current session', async () => {
+    const user = { $id: '1', name: 'John Doe', email: 'john@example.com' }
+    mockedGet.mockResolvedValue(user)
+
+    const queryClient = new QueryClient()
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useSession(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(user)
+    })
+
+    expect(mockedGet).toHaveBeenCalled()
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "jsx": "react-jsx",
     "module": "ESNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "types": ["vite/client"],
+    "types": ["vite/client", "vitest"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,4 +17,7 @@ export default defineConfig({
       "@": resolve(__dirname, "./src"),
     },
   },
+  test: {
+    environment: "jsdom",
+  },
 });


### PR DESCRIPTION
## Summary
- configure Vitest to use jsdom environment
- add unit tests for useSession hook with mocked Appwrite client
- add NavUser component test mocking hooks and API calls

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e6df2774832e94f1f92fea2b015f