### PR TITLE
refactor: move chat scroll to page

### DIFF
--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -1,64 +1,26 @@
-import { ArrowDown, Loader2 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { Loader2 } from "lucide-react";
 import { ChatBubble } from "./chat-bubble";
 import type { UIMessage } from "ai";
+import { cn } from "@/lib/utils";
 
 interface ChatMessagesProps {
   messages: UIMessage[];
   isLoading: boolean;
+  className?: string;
 }
 
-export function ChatMessages({ messages, isLoading }: ChatMessagesProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [isAtBottom, setIsAtBottom] = useState(true);
-
-  const scrollToBottom = () => {
-    const el = containerRef.current;
-    if (el) {
-      el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
-    }
-  };
-
-  useEffect(() => {
-    if (isAtBottom) {
-      scrollToBottom();
-    }
-  }, [messages, isAtBottom]);
-
-  const handleScroll = () => {
-    const el = containerRef.current;
-    if (!el) return;
-    const threshold = 20;
-    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= threshold;
-    setIsAtBottom(atBottom);
-  };
-
+export function ChatMessages({ messages, isLoading, className }: ChatMessagesProps) {
   return (
-    <div className="relative flex flex-1 w-full min-h-0">
-      <div
-        ref={containerRef}
-        onScroll={handleScroll}
-        className="chat-scrollbar flex flex-1 min-h-0 flex-col space-y-4 overflow-y-auto overflow-x-hidden py-4"
-      >
-        {messages.map((m) => (
-          <ChatBubble key={m.id} role={m.role}>
-            {m.parts.map((p) => (p.type === "text" ? p.text : "")).join("")}
-          </ChatBubble>
-        ))}
-        {isLoading && (
-          <div className="flex justify-center">
-            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-          </div>
-        )}
-      </div>
-      {!isAtBottom && (
-        <button
-          onClick={scrollToBottom}
-          className="absolute bottom-4 right-4 rounded-full bg-primary p-2 text-primary-foreground shadow"
-          aria-label="Scroll to bottom"
-        >
-          <ArrowDown className="h-4 w-4" />
-        </button>
+    <div className={cn("flex flex-1 flex-col space-y-4", className)}>
+      {messages.map((m) => (
+        <ChatBubble key={m.id} role={m.role}>
+          {m.parts.map((p) => (p.type === "text" ? p.text : "")).join("")}
+        </ChatBubble>
+      ))}
+      {isLoading && (
+        <div className="flex justify-center">
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        </div>
       )}
     </div>
   );

--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -1,15 +1,40 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useChat } from "@ai-sdk/react";
 import { useTranslate } from "@tolgee/react";
 import { OpenAIChatTransport } from "@/lib/openai-chat-transport";
 import { ChatHeader } from "./chat-header";
 import { ChatMessages } from "./chat-messages";
 import { ChatFooter } from "./chat-footer";
+import { ArrowDown } from "lucide-react";
 
 export function Chat() {
   const { t } = useTranslate();
   const transport = useMemo(() => new OpenAIChatTransport(), []);
   const { messages, sendMessage, status } = useChat({ transport });
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isAtBottom, setIsAtBottom] = useState(true);
+
+  const scrollToBottom = () => {
+    const el = containerRef.current;
+    if (el) {
+      el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+    }
+  };
+
+  useEffect(() => {
+    if (isAtBottom) {
+      scrollToBottom();
+    }
+  }, [messages, isAtBottom]);
+
+  const handleScroll = () => {
+    const el = containerRef.current;
+    if (!el) return;
+    const threshold = 20;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= threshold;
+    setIsAtBottom(atBottom);
+  };
 
   async function handleSubmit(value: string) {
     if (!value.trim()) return;
@@ -26,10 +51,27 @@ export function Chat() {
   ];
 
   return (
-    <div className="flex flex-1 min-h-0 flex-col items-center px-4 overflow-x-hidden overflow-y-auto">
+    <div className="flex flex-1 min-h-0 flex-col items-center px-4">
       <ChatHeader />
-      <div className="flex w-full max-w-2xl flex-1 min-h-0 flex-col overflow-x-hidden overflow-y-auto">
-        <ChatMessages messages={messages} isLoading={status !== "ready"} />
+      <div className="flex w-full max-w-2xl flex-1 min-h-0 flex-col">
+        <div className="relative flex flex-1 w-full min-h-0">
+          <div
+            ref={containerRef}
+            onScroll={handleScroll}
+            className="chat-scrollbar flex flex-1 min-h-0 flex-col overflow-y-auto overflow-x-hidden py-4"
+          >
+            <ChatMessages messages={messages} isLoading={status !== "ready"} />
+          </div>
+          {!isAtBottom && (
+            <button
+              onClick={scrollToBottom}
+              className="absolute bottom-4 right-4 rounded-full bg-primary p-2 text-primary-foreground shadow"
+              aria-label="Scroll to bottom"
+            >
+              <ArrowDown className="h-4 w-4" />
+            </button>
+          )}
+        </div>
         <ChatFooter
           onSubmit={handleSubmit}
           disabled={status !== "ready"}


### PR DESCRIPTION
## Summary
- relocate chat scroll logic from message component to chat page container
- simplify ChatMessages component to render message list without scroll handling
- manage scroll-to-bottom behavior within Chat component with arrow control

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e9cc2c48832e8b67a29f3e27842c