### PR TITLE
refactor: move chat scrollbar to route

### DIFF
--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -26,7 +26,7 @@ export function Chat() {
   ];
 
   return (
-    <>
+    <div className="flex flex-1 min-h-0 flex-col items-center px-4 overflow-x-hidden">
       <ChatHeader />
       <div className="flex w-full max-w-2xl flex-1 min-h-0 flex-col overflow-x-hidden">
         <ChatMessages messages={messages} isLoading={status !== "ready"} />
@@ -36,7 +36,7 @@ export function Chat() {
           placeholders={placeholders}
         />
       </div>
-    </>
+    </div>
   );
 }
 

--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -26,7 +26,7 @@ export function Chat() {
   ];
 
   return (
-    <div className="flex flex-1 min-h-0 flex-col items-center px-4 overflow-x-hidden overflow-y-auto">
+    <>
       <ChatHeader />
       <div className="flex w-full max-w-2xl flex-1 min-h-0 flex-col overflow-x-hidden overflow-y-auto">
         <ChatMessages messages={messages} isLoading={status !== "ready"} />
@@ -36,7 +36,7 @@ export function Chat() {
           placeholders={placeholders}
         />
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -28,7 +28,7 @@ export function Chat() {
   return (
     <>
       <ChatHeader />
-      <div className="flex w-full max-w-2xl flex-1 min-h-0 flex-col overflow-x-hidden overflow-y-auto">
+      <div className="flex w-full max-w-2xl flex-1 min-h-0 flex-col overflow-x-hidden">
         <ChatMessages messages={messages} isLoading={status !== "ready"} />
         <ChatFooter
           onSubmit={handleSubmit}

--- a/src/routes/__authenticatedLayout/chat.tsx
+++ b/src/routes/__authenticatedLayout/chat.tsx
@@ -2,6 +2,14 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Chat } from "@/components/chat";
 
 export const Route = createFileRoute("/__authenticatedLayout/chat")({
-  component: Chat,
+  component: RouteComponent,
 });
+
+function RouteComponent() {
+  return (
+    <div className="flex flex-1 min-h-0 flex-col items-center px-4 overflow-x-hidden overflow-y-auto">
+      <Chat />
+    </div>
+  );
+}
 

--- a/src/routes/__authenticatedLayout/chat.tsx
+++ b/src/routes/__authenticatedLayout/chat.tsx
@@ -6,10 +6,6 @@ export const Route = createFileRoute("/__authenticatedLayout/chat")({
 });
 
 function RouteComponent() {
-  return (
-    <div className="flex flex-1 min-h-0 flex-col items-center px-4 overflow-x-hidden overflow-y-auto">
-      <Chat />
-    </div>
-  );
+  return <Chat />;
 }
 


### PR DESCRIPTION
## Summary
- move chat scrollbar control from Chat component to chat route
- simplify Chat component layout

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0eb710b98832e8f71902e0fb25841