### PR TITLE
feat: add page header portal

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-portal": "^1.1.9",
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.7
         version: 2.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-portal':
+        specifier: ^1.1.9
+        version: 1.1.9(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-progress':
         specifier: ^1.1.7
         version: 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)

--- a/src/components/portal.tsx
+++ b/src/components/portal.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { Portal as RadixPortal } from "@radix-ui/react-portal";
+
+interface PortalProps {
+  containerId: string;
+  children: React.ReactNode;
+}
+
+export function Portal({ containerId, children }: PortalProps) {
+  const container =
+    typeof document !== "undefined"
+      ? document.getElementById(containerId)
+      : null;
+  if (!container) return null;
+  return <RadixPortal container={container}>{children}</RadixPortal>;
+}

--- a/src/routes/__authenticatedLayout.tsx
+++ b/src/routes/__authenticatedLayout.tsx
@@ -59,6 +59,7 @@ function RouteComponent() {
           <div className="flex items-center gap-2 px-4">
             <SidebarTrigger className="-ml-1" />
           </div>
+          <div id="page-header-portal" className="flex-1" />
           <div className="ml-auto px-4">
             <ModeToggle />
           </div>


### PR DESCRIPTION
## Summary
- install Radix UI Portal utility
- add header portal target to authenticated layout
- provide generic Portal component for injecting header content

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ebc9d0f0832e9cc9faf39673ab6e