### PR TITLE
Render chat header in page header via portal

### DIFF
--- a/src/components/chat/chat-header.tsx
+++ b/src/components/chat/chat-header.tsx
@@ -2,9 +2,5 @@ import { useTranslate } from "@tolgee/react";
 
 export function ChatHeader() {
   const { t } = useTranslate();
-  return (
-    <header className="w-full max-w-2xl py-2">
-      <h2 className="text-lg font-medium">{t("chat.title")}</h2>
-    </header>
-  );
+  return <h2 className="text-lg font-medium">{t("chat.title")}</h2>;
 }

--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -5,6 +5,7 @@ import { OpenAIChatTransport } from "@/lib/openai-chat-transport";
 import { ChatHeader } from "./chat-header";
 import { ChatMessages } from "./chat-messages";
 import { ChatFooter } from "./chat-footer";
+import { Portal } from "@/components/portal";
 
 export function Chat() {
   const { t } = useTranslate();
@@ -26,17 +27,21 @@ export function Chat() {
   ];
 
   return (
-    <div className="flex flex-1 min-h-0 flex-col items-center px-4 overflow-x-hidden overflow-y-auto">
-      <ChatHeader />
-      <div className="flex w-full max-w-2xl flex-1 min-h-0 flex-col overflow-x-hidden overflow-y-auto">
-        <ChatMessages messages={messages} isLoading={status !== "ready"} />
-        <ChatFooter
-          onSubmit={handleSubmit}
-          disabled={status !== "ready"}
-          placeholders={placeholders}
-        />
+    <>
+      <Portal containerId="page-header-portal">
+        <ChatHeader />
+      </Portal>
+      <div className="flex flex-1 min-h-0 flex-col items-center px-4 overflow-x-hidden overflow-y-auto">
+        <div className="flex w-full max-w-2xl flex-1 min-h-0 flex-col overflow-x-hidden overflow-y-auto">
+          <ChatMessages messages={messages} isLoading={status !== "ready"} />
+          <ChatFooter
+            onSubmit={handleSubmit}
+            disabled={status !== "ready"}
+            placeholders={placeholders}
+          />
+        </div>
       </div>
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- Render ChatHeader into page header using the new Portal
- Simplify ChatHeader to a heading for compatibility with the page header

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f068c798832ea4825cf4b62d8a94