### PR TITLE
Center chat input when empty and animate to bottom on messages

### DIFF
--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -6,6 +6,8 @@ import { ChatHeader } from "./chat-header";
 import { ChatMessages } from "./chat-messages";
 import { ChatFooter } from "./chat-footer";
 import { Portal } from "@/components/portal";
+import { cn } from "@/lib/utils";
+import { AnimatePresence, motion } from "motion/react";
 
 export function Chat() {
   const { t } = useTranslate();
@@ -26,20 +28,47 @@ export function Chat() {
     t("chat.placeholder.shareThoughts"),
   ];
 
+  const hasMessages = messages.length > 0;
+
   return (
     <>
       <Portal containerId="page-header-portal">
         <ChatHeader />
       </Portal>
       <div className="flex flex-1 min-h-0 flex-col items-center px-4 overflow-x-hidden overflow-y-auto">
-        <div className="flex w-full max-w-2xl flex-1 min-h-0 flex-col overflow-x-hidden overflow-y-auto">
-          <ChatMessages messages={messages} isLoading={status !== "ready"} />
-          <ChatFooter
-            onSubmit={handleSubmit}
-            disabled={status !== "ready"}
-            placeholders={placeholders}
-          />
-        </div>
+        <motion.div
+          layout
+          transition={{ type: "spring", bounce: 0.2 }}
+          className={cn(
+            "flex w-full max-w-2xl flex-1 min-h-0 flex-col overflow-x-hidden overflow-y-auto",
+            !hasMessages && "justify-center"
+          )}
+        >
+          <AnimatePresence initial={false}>
+            {hasMessages && (
+              <motion.div
+                key="messages"
+                layout
+                className="flex-1"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+              >
+                <ChatMessages
+                  messages={messages}
+                  isLoading={status !== "ready"}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
+          <motion.div layout>
+            <ChatFooter
+              onSubmit={handleSubmit}
+              disabled={status !== "ready"}
+              placeholders={placeholders}
+            />
+          </motion.div>
+        </motion.div>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- center chat input when conversation is empty
- animate input to bottom once messages arrive

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f23b2bbc832e8244c802f7ff439f