### PR TITLE
Animate chat input transition from empty state

### DIFF
--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -1,16 +1,19 @@
 import { useMemo } from "react";
 import { useChat } from "@ai-sdk/react";
 import { useTranslate } from "@tolgee/react";
+import { motion } from "motion/react";
 import { OpenAIChatTransport } from "@/lib/openai-chat-transport";
 import { ChatHeader } from "./chat-header";
 import { ChatMessages } from "./chat-messages";
 import { ChatFooter } from "./chat-footer";
 import { Portal } from "@/components/portal";
+import { cn } from "@/lib/utils";
 
 export function Chat() {
   const { t } = useTranslate();
   const transport = useMemo(() => new OpenAIChatTransport(), []);
   const { messages, sendMessage, status } = useChat({ transport });
+  const hasMessages = messages.length > 0;
 
   async function handleSubmit(value: string) {
     if (!value.trim()) return;
@@ -32,13 +35,25 @@ export function Chat() {
         <ChatHeader />
       </Portal>
       <div className="flex flex-1 min-h-0 flex-col items-center px-4 overflow-x-hidden overflow-y-auto">
-        <div className="flex w-full max-w-2xl flex-1 min-h-0 flex-col overflow-x-hidden overflow-y-auto">
-          <ChatMessages messages={messages} isLoading={status !== "ready"} />
-          <ChatFooter
-            onSubmit={handleSubmit}
-            disabled={status !== "ready"}
-            placeholders={placeholders}
-          />
+        <div
+          className={cn(
+            "flex w-full max-w-2xl flex-1 min-h-0 flex-col overflow-x-hidden overflow-y-auto",
+            !hasMessages && "justify-center"
+          )}
+        >
+          {hasMessages && (
+            <ChatMessages messages={messages} isLoading={status !== "ready"} />
+          )}
+          <motion.div
+            layout
+            transition={{ type: "spring", stiffness: 500, damping: 40 }}
+          >
+            <ChatFooter
+              onSubmit={handleSubmit}
+              disabled={status !== "ready"}
+              placeholders={placeholders}
+            />
+          </motion.div>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- center chat input when there are no messages
- animate input to bottom once conversation starts

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a0f23b2bbc832e8244c802f7ff439f