### PR TITLE
feat: animate chat input position

### DIFF
--- a/src/components/chat/chat-footer.tsx
+++ b/src/components/chat/chat-footer.tsx
@@ -25,7 +25,9 @@ export function ChatFooter({
       className={cn("w-full shrink-0 bg-background p-4", className)}
     >
       {showPrompt && (
-        <p className="mb-4 text-start text-2xl text-muted-foreground">
+        <p
+          className="mb-4 w-full max-w-xl mx-auto text-start text-2xl text-muted-foreground"
+        >
           {t("chat.prompt")}
         </p>
       )}

--- a/src/components/chat/chat-footer.tsx
+++ b/src/components/chat/chat-footer.tsx
@@ -1,19 +1,30 @@
+import { motion } from "motion/react";
 import { PlaceholdersAndVanishInput } from "@/components/ui/placeholders-and-vanish-input";
+import { cn } from "@/lib/utils";
 
 interface ChatFooterProps {
   onSubmit: (value: string) => void;
   disabled: boolean;
   placeholders: string[];
+  className?: string;
 }
 
-export function ChatFooter({ onSubmit, disabled, placeholders }: ChatFooterProps) {
+export function ChatFooter({
+  onSubmit,
+  disabled,
+  placeholders,
+  className,
+}: ChatFooterProps) {
   return (
-    <div className="w-full shrink-0 bg-background p-4">
+    <motion.div
+      layout
+      className={cn("w-full shrink-0 bg-background p-4", className)}
+    >
       <PlaceholdersAndVanishInput
         placeholders={placeholders}
         onSubmit={onSubmit}
         disabled={disabled}
       />
-    </div>
+    </motion.div>
   );
 }

--- a/src/components/chat/chat-footer.tsx
+++ b/src/components/chat/chat-footer.tsx
@@ -8,6 +8,7 @@ interface ChatFooterProps {
   disabled: boolean;
   placeholders: string[];
   className?: string;
+  showPrompt?: boolean;
 }
 
 export function ChatFooter({
@@ -15,6 +16,7 @@ export function ChatFooter({
   disabled,
   placeholders,
   className,
+  showPrompt = false,
 }: ChatFooterProps) {
   const { t } = useTranslate();
   return (
@@ -22,9 +24,11 @@ export function ChatFooter({
       layout
       className={cn("w-full shrink-0 bg-background p-4", className)}
     >
-      <p className="mb-2 text-center text-sm text-muted-foreground">
-        {t("chat.prompt")}
-      </p>
+      {showPrompt && (
+        <p className="mb-4 text-start text-2xl text-muted-foreground">
+          {t("chat.prompt")}
+        </p>
+      )}
       <PlaceholdersAndVanishInput
         placeholders={placeholders}
         onSubmit={onSubmit}

--- a/src/components/chat/chat-footer.tsx
+++ b/src/components/chat/chat-footer.tsx
@@ -1,4 +1,5 @@
 import { motion } from "motion/react";
+import { useTranslate } from "@tolgee/react";
 import { PlaceholdersAndVanishInput } from "@/components/ui/placeholders-and-vanish-input";
 import { cn } from "@/lib/utils";
 
@@ -15,11 +16,15 @@ export function ChatFooter({
   placeholders,
   className,
 }: ChatFooterProps) {
+  const { t } = useTranslate();
   return (
     <motion.div
       layout
       className={cn("w-full shrink-0 bg-background p-4", className)}
     >
+      <p className="mb-2 text-center text-sm text-muted-foreground">
+        {t("chat.prompt")}
+      </p>
       <PlaceholdersAndVanishInput
         placeholders={placeholders}
         onSubmit={onSubmit}

--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -26,6 +26,8 @@ export function Chat() {
     t("chat.placeholder.shareThoughts"),
   ];
 
+  const hasMessages = messages.length > 0;
+
   return (
     <>
       <Portal containerId="page-header-portal">
@@ -33,11 +35,14 @@ export function Chat() {
       </Portal>
       <div className="flex flex-1 min-h-0 flex-col items-center px-4 overflow-x-hidden overflow-y-auto">
         <div className="flex w-full max-w-2xl flex-1 min-h-0 flex-col overflow-x-hidden overflow-y-auto">
-          <ChatMessages messages={messages} isLoading={status !== "ready"} />
+          {hasMessages && (
+            <ChatMessages messages={messages} isLoading={status !== "ready"} />
+          )}
           <ChatFooter
             onSubmit={handleSubmit}
             disabled={status !== "ready"}
             placeholders={placeholders}
+            className={hasMessages ? "mt-auto" : "my-auto"}
           />
         </div>
       </div>

--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -43,6 +43,7 @@ export function Chat() {
             disabled={status !== "ready"}
             placeholders={placeholders}
             className={hasMessages ? "mt-auto" : "my-auto"}
+            showPrompt={!hasMessages}
           />
         </div>
       </div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -76,6 +76,7 @@
   },
   "chat": {
     "title": "Chat",
+    "prompt": "What can I do for you?",
     "placeholder": {
       "typeYourMessage": "Type your message",
       "askQuestion": "Ask a question",

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -76,6 +76,7 @@
   },
   "chat": {
     "title": "Bate-papo",
+    "prompt": "O que posso fazer por você?",
     "placeholder": {
       "typeYourMessage": "Digite sua mensagem",
       "askQuestion": "Faça uma pergunta",


### PR DESCRIPTION
## Summary
- animate chat input from center to bottom when messages appear
- add motion layout to chat footer
- center input when chat is empty

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0f23b2bbc832e8244c802f7ff439f