### PR TITLE
Animate chat input position

### DIFF
--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from "react";
 import { useChat } from "@ai-sdk/react";
 import { useTranslate } from "@tolgee/react";
+import { motion } from "motion/react";
+import { cn } from "@/lib/utils";
 import { OpenAIChatTransport } from "@/lib/openai-chat-transport";
 import { ChatHeader } from "./chat-header";
 import { ChatMessages } from "./chat-messages";
@@ -11,6 +13,7 @@ export function Chat() {
   const { t } = useTranslate();
   const transport = useMemo(() => new OpenAIChatTransport(), []);
   const { messages, sendMessage, status } = useChat({ transport });
+  const hasMessages = messages.length > 0;
 
   async function handleSubmit(value: string) {
     if (!value.trim()) return;
@@ -33,12 +36,23 @@ export function Chat() {
       </Portal>
       <div className="flex flex-1 min-h-0 flex-col items-center px-4 overflow-x-hidden overflow-y-auto">
         <div className="flex w-full max-w-2xl flex-1 min-h-0 flex-col overflow-x-hidden overflow-y-auto">
-          <ChatMessages messages={messages} isLoading={status !== "ready"} />
-          <ChatFooter
-            onSubmit={handleSubmit}
-            disabled={status !== "ready"}
-            placeholders={placeholders}
-          />
+          {hasMessages && (
+            <ChatMessages messages={messages} isLoading={status !== "ready"} />
+          )}
+          <motion.div
+            layout
+            transition={{ duration: 0.3 }}
+            className={cn(
+              "w-full",
+              hasMessages ? "" : "flex flex-1 items-center"
+            )}
+          >
+            <ChatFooter
+              onSubmit={handleSubmit}
+              disabled={status !== "ready"}
+              placeholders={placeholders}
+            />
+          </motion.div>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- center chat input when no messages are present
- animate chat input to bottom once conversation starts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0f23b2bbc832e8244c802f7ff439f