### PR TITLE
feat(chat): show bubble typing indicator

### DIFF
--- a/src/components/chat/chat-bubble.tsx
+++ b/src/components/chat/chat-bubble.tsx
@@ -1,22 +1,26 @@
 import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
 import type { ReactNode } from "react";
 
 interface ChatBubbleProps {
   role: string;
   children: ReactNode;
+  layoutId?: string;
 }
 
-export function ChatBubble({ role, children }: ChatBubbleProps) {
+export function ChatBubble({ role, children, layoutId }: ChatBubbleProps) {
   return (
-    <div className={cn("flex", role === "user" ? "justify-end" : "justify-start")}> 
-      <div
+    <div className={cn("flex", role === "user" ? "justify-end" : "justify-start")}>
+      <motion.div
+        layout
+        layoutId={layoutId}
         className={cn(
           "max-w-[80%] break-words whitespace-pre-wrap rounded-lg px-3 py-2 text-sm",
           role === "user" ? "bg-primary text-primary-foreground" : "bg-muted"
         )}
       >
         {children}
-      </div>
+      </motion.div>
     </div>
   );
 }

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -11,18 +11,18 @@ interface ChatMessagesProps {
 
 function AnimatedEllipsis() {
   return (
-    <motion.span
-      className="inline-block overflow-hidden text-muted-foreground"
-      animate={{ width: ["0ch", "1ch", "2ch", "3ch", "0ch"] }}
-      transition={{
-        duration: 1.5,
-        ease: "linear",
-        repeat: Infinity,
-        times: [0, 0.25, 0.5, 0.75, 1],
-      }}
-    >
-      ...
-    </motion.span>
+    <span className="inline-flex w-[3ch] text-muted-foreground">
+      {[0, 1, 2].map((i) => (
+        <motion.span
+          key={i}
+          className="w-[1ch]"
+          animate={{ opacity: [0, 1, 0] }}
+          transition={{ duration: 1.2, repeat: Infinity, delay: i * 0.2 }}
+        >
+          .
+        </motion.span>
+      ))}
+    </span>
   );
 }
 

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, Loader2 } from "lucide-react";
+import { ArrowDown } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ChatBubble } from "./chat-bubble";
 import type { UIMessage } from "ai";
@@ -46,9 +46,9 @@ export function ChatMessages({ messages, isLoading }: ChatMessagesProps) {
           </ChatBubble>
         ))}
         {isLoading && (
-          <div className="flex justify-center">
-            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-          </div>
+          <ChatBubble role="assistant">
+            <span className="text-muted-foreground">...</span>
+          </ChatBubble>
         )}
       </div>
       {!isAtBottom && (

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -17,7 +17,7 @@ function AnimatedEllipsis() {
           key={i}
           className="w-[1ch]"
           animate={{ opacity: [0, 1, 0] }}
-          transition={{ duration: 1.2, repeat: Infinity, delay: i * 0.2 }}
+          transition={{ duration: 0.8, repeat: Infinity, delay: i * 0.15 }}
         >
           .
         </motion.span>
@@ -30,6 +30,7 @@ export function ChatMessages({ messages, isLoading }: ChatMessagesProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isAtBottom, setIsAtBottom] = useState(true);
   const prevIsLoading = useRef(isLoading);
+  const loadingStartIndex = useRef<number>(Infinity);
 
   const scrollToBottom = () => {
     const el = containerRef.current;
@@ -44,8 +45,13 @@ export function ChatMessages({ messages, isLoading }: ChatMessagesProps) {
     }
   }, [messages, isAtBottom]);
   useEffect(() => {
+    if (isLoading && !prevIsLoading.current) {
+      loadingStartIndex.current = messages.length;
+    } else if (!isLoading && prevIsLoading.current) {
+      loadingStartIndex.current = Infinity;
+    }
     prevIsLoading.current = isLoading;
-  }, [isLoading]);
+  }, [isLoading, messages.length]);
 
   const handleScroll = () => {
     const el = containerRef.current;
@@ -64,7 +70,9 @@ export function ChatMessages({ messages, isLoading }: ChatMessagesProps) {
       >
         {messages.map((m, idx) => {
           const isLatestAssistant = idx === messages.length - 1 && m.role === "assistant";
-          if (isLoading && isLatestAssistant) {
+          const isStreamingAssistant =
+            isLoading && m.role === "assistant" && idx >= loadingStartIndex.current;
+          if (isStreamingAssistant) {
             return null;
           }
           return (

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -11,7 +11,7 @@ interface ChatMessagesProps {
 
 function AnimatedEllipsis() {
   return (
-    <span className="inline-flex w-[3ch] text-muted-foreground">
+    <span className="inline-flex w-[3ch] font-bold text-muted-foreground">
       {[0, 1, 2].map((i) => (
         <motion.span
           key={i}
@@ -62,19 +62,25 @@ export function ChatMessages({ messages, isLoading }: ChatMessagesProps) {
         onScroll={handleScroll}
         className="chat-scrollbar flex flex-1 min-h-0 flex-col space-y-4 overflow-y-auto overflow-x-hidden py-4"
       >
-        {messages.map((m, idx) => (
-          <ChatBubble
-            key={m.id}
-            role={m.role}
-            layoutId={
-              !isLoading && prevIsLoading.current && idx === messages.length - 1 && m.role === "assistant"
-                ? "assistant-bubble"
-                : undefined
-            }
-          >
-            {m.parts.map((p) => (p.type === "text" ? p.text : "")).join("")}
-          </ChatBubble>
-        ))}
+        {messages.map((m, idx) => {
+          const isLatestAssistant = idx === messages.length - 1 && m.role === "assistant";
+          if (isLoading && isLatestAssistant) {
+            return null;
+          }
+          return (
+            <ChatBubble
+              key={m.id}
+              role={m.role}
+              layoutId={
+                !isLoading && prevIsLoading.current && isLatestAssistant
+                  ? "assistant-bubble"
+                  : undefined
+              }
+            >
+              {m.parts.map((p) => (p.type === "text" ? p.text : "")).join("")}
+            </ChatBubble>
+          );
+        })}
         {isLoading && (
           <ChatBubble role="assistant" layoutId="assistant-bubble">
             <AnimatedEllipsis />


### PR DESCRIPTION
## Summary
- replace center spinner with left-side chat bubble to indicate processing

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f8f563a4832eb17d481cdcf53ab7