### PR TITLE
feat: submit contact and feedback via Appwrite function

### DIFF
--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -9,13 +9,13 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import useSession from "@/hooks/queries/user";
+import useExecution from "@/hooks/use-execution";
 import { cn } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTranslate } from "@tolgee/react";
-import { useEffect } from "react";
+import { ExecutionMethod } from "appwrite";
 import { useForm } from "react-hook-form";
-import useSession from "@/hooks/queries/user";
-import useExecution from "@/hooks/use-execution";
 import { toast } from "sonner";
 import { z } from "zod";
 
@@ -44,12 +44,6 @@ export function ContactForm({ className, onSubmitted }: ContactFormProps) {
     defaultValues: { email: session?.email ?? "", message: "" },
   });
 
-  useEffect(() => {
-    if (session?.email) {
-      formMethods.setValue("email", session.email);
-    }
-  }, [session, formMethods]);
-
   const onSubmit = (values: FormValues) => {
     mutate(
       {
@@ -59,6 +53,8 @@ export function ContactForm({ className, onSubmitted }: ContactFormProps) {
           message: values.message,
           userId: session?.$id ?? null,
         },
+        path: "/contact",
+        method: ExecutionMethod.POST,
       },
       {
         onSuccess: () => {

--- a/src/components/feedback-form.tsx
+++ b/src/components/feedback-form.tsx
@@ -9,13 +9,13 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import useSession from "@/hooks/queries/user";
+import useExecution from "@/hooks/use-execution";
 import { cn } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTranslate } from "@tolgee/react";
-import { useEffect } from "react";
+import { ExecutionMethod } from "appwrite";
 import { useForm } from "react-hook-form";
-import useSession from "@/hooks/queries/user";
-import useExecution from "@/hooks/use-execution";
 import { toast } from "sonner";
 import { z } from "zod";
 
@@ -44,12 +44,6 @@ export function FeedbackForm({ className, onSubmitted }: FeedbackFormProps) {
     defaultValues: { email: session?.email ?? "", message: "" },
   });
 
-  useEffect(() => {
-    if (session?.email) {
-      formMethods.setValue("email", session.email);
-    }
-  }, [session, formMethods]);
-
   const onSubmit = (values: FormValues) => {
     mutate(
       {
@@ -59,6 +53,8 @@ export function FeedbackForm({ className, onSubmitted }: FeedbackFormProps) {
           message: values.message,
           userId: session?.$id ?? null,
         },
+        path: "/feedback",
+        method: ExecutionMethod.POST,
       },
       {
         onSuccess: () => {
@@ -126,4 +122,3 @@ export function FeedbackForm({ className, onSubmitted }: FeedbackFormProps) {
     </Form>
   );
 }
-

--- a/src/components/feedback-form.tsx
+++ b/src/components/feedback-form.tsx
@@ -15,6 +15,7 @@ import { useTranslate } from "@tolgee/react";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import useSession from "@/hooks/queries/user";
+import useExecution from "@/hooks/use-execution";
 import { toast } from "sonner";
 import { z } from "zod";
 
@@ -26,6 +27,7 @@ interface FeedbackFormProps {
 export function FeedbackForm({ className, onSubmitted }: FeedbackFormProps) {
   const { t } = useTranslate();
   const session = useSession().data;
+  const { mutate, status } = useExecution();
 
   const formSchema = z.object({
     email: z
@@ -48,10 +50,25 @@ export function FeedbackForm({ className, onSubmitted }: FeedbackFormProps) {
     }
   }, [session, formMethods]);
 
-  const onSubmit = () => {
-    toast.success(t("feedback.success"));
-    formMethods.reset({ email: session?.email ?? "", message: "" });
-    onSubmitted?.();
+  const onSubmit = (values: FormValues) => {
+    mutate(
+      {
+        functionId: "689feffd0007270a4aa1",
+        body: {
+          email: values.email,
+          message: values.message,
+          userId: session?.$id ?? null,
+        },
+      },
+      {
+        onSuccess: () => {
+          toast.success(t("feedback.success"));
+          formMethods.reset({ email: session?.email ?? "", message: "" });
+          onSubmitted?.();
+        },
+        onError: (err: any) => toast.error(err.message),
+      }
+    );
   };
 
   return (
@@ -96,7 +113,13 @@ export function FeedbackForm({ className, onSubmitted }: FeedbackFormProps) {
             </FormItem>
           )}
         />
-        <Button type="submit" className="w-full">
+        <Button
+          type="submit"
+          className="w-full"
+          loading={
+            status === "pending" ? `${t("feedback.loading")}...` : undefined
+          }
+        >
           {t("feedback.submit")}
         </Button>
       </form>


### PR DESCRIPTION
## Summary
- invoke Appwrite function `689feffd0007270a4aa1` from contact and feedback forms via `useExecution`
- remove unused Appwrite databases client

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0fa5ebc64832ea73e5d31ccb8f623