### PR TITLE
feat: add subject field to contact form

### DIFF
--- a/appwrite.config.json
+++ b/appwrite.config.json
@@ -113,6 +113,15 @@
                     "array": false,
                     "format": "email",
                     "default": null
+                },
+                {
+                    "key": "subject",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 128,
+                    "default": null,
+                    "encrypt": false
                 }
             ],
             "indexes": []

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -34,6 +34,7 @@ export function ContactForm({ className, onSubmitted }: ContactFormProps) {
       .string()
       .nonempty({ message: t("validation.required") })
       .email({ message: t("validation.invalidEmail") }),
+    subject: z.string().nonempty({ message: t("validation.required") }),
     message: z.string().nonempty({ message: t("validation.required") }),
   });
 
@@ -41,7 +42,7 @@ export function ContactForm({ className, onSubmitted }: ContactFormProps) {
 
   const formMethods = useForm<FormValues>({
     resolver: zodResolver(formSchema),
-    defaultValues: { email: session?.email ?? "", message: "" },
+    defaultValues: { email: session?.email ?? "", subject: "", message: "" },
   });
 
   const onSubmit = (values: FormValues) => {
@@ -50,6 +51,7 @@ export function ContactForm({ className, onSubmitted }: ContactFormProps) {
         functionId: "689feffd0007270a4aa1",
         body: {
           email: values.email,
+          subject: values.subject,
           message: values.message,
           userId: session?.$id ?? null,
         },
@@ -59,7 +61,11 @@ export function ContactForm({ className, onSubmitted }: ContactFormProps) {
       {
         onSuccess: () => {
           toast.success(t("contact.success"));
-          formMethods.reset({ email: session?.email ?? "", message: "" });
+          formMethods.reset({
+            email: session?.email ?? "",
+            subject: "",
+            message: "",
+          });
           onSubmitted?.();
         },
         onError: (err: any) => toast.error(err.message),
@@ -92,6 +98,22 @@ export function ContactForm({ className, onSubmitted }: ContactFormProps) {
             )}
           />
         )}
+        <FormField
+          control={formMethods.control}
+          name="subject"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("contact.subject")}</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder={t("contact.subjectPlaceholder")}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
         <FormField
           control={formMethods.control}
           name="message"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -70,6 +70,8 @@
     "description": "Have questions? We're here to help.",
     "email": "Email",
     "emailPlaceholder": "Write your email...",
+    "subject": "Subject",
+    "subjectPlaceholder": "Write your subject...",
     "message": "Message",
     "messagePlaceholder": "Write your message...",
     "submit": "Send message",

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -69,6 +69,8 @@
     "description": "Tem perguntas? Estamos aqui para ajudar.",
     "email": "Email",
     "emailPlaceholder": "Digite seu email...",
+    "subject": "Assunto",
+    "subjectPlaceholder": "Digite seu assunto...",
     "message": "Mensagem",
     "messagePlaceholder": "Digite sua mensagem...",
     "submit": "Enviar mensagem",

--- a/src/types/appwrite.d.ts
+++ b/src/types/appwrite.d.ts
@@ -18,4 +18,5 @@ export type Contacts = Models.Document & {
     userId: string | null;
     message: string;
     email: string;
+    subject: string;
 }


### PR DESCRIPTION
## Summary
- add subject field to contact form
- support new subject field across translations and Appwrite types

## Testing
- `pnpm test`
- `pnpm generate-types` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68a1034647c4832e80a983a5adbd809f