### PR TITLE
feat(chat): animate bubble typing indicator

### DIFF
--- a/src/components/chat/chat-bubble.tsx
+++ b/src/components/chat/chat-bubble.tsx
@@ -1,22 +1,26 @@
 import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
 import type { ReactNode } from "react";
 
 interface ChatBubbleProps {
   role: string;
   children: ReactNode;
+  layoutId?: string;
 }
 
-export function ChatBubble({ role, children }: ChatBubbleProps) {
+export function ChatBubble({ role, children, layoutId }: ChatBubbleProps) {
   return (
-    <div className={cn("flex", role === "user" ? "justify-end" : "justify-start")}> 
-      <div
+    <div className={cn("flex", role === "user" ? "justify-end" : "justify-start")}>
+      <motion.div
+        layout
+        layoutId={layoutId}
         className={cn(
           "max-w-[80%] break-words whitespace-pre-wrap rounded-lg px-3 py-2 text-sm",
           role === "user" ? "bg-primary text-primary-foreground" : "bg-muted"
         )}
       >
         {children}
-      </div>
+      </motion.div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- animate ellipsis in typing indicator bubble
- use shared layout animation to transition from typing indicator to message
- keep typing indicator width constant by fading dots instead of resizing
- hide streaming assistant message so ellipsis morphs into final bubble
- make typing indicator ellipsis bold
- speed up ellipsis animation
- retain previous assistant bubble when loading the next reply
- refactor message list to use Motion's `LayoutGroup` for reliable bubble morphing
- simplify streaming detection logic so the ellipsis bubble cleanly transitions into the reply

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f8f563a4832eb17d481cdcf53ab7