### PR TITLE
feat(chat): animate bubble typing indicator

### DIFF
--- a/src/components/chat/chat-bubble.tsx
+++ b/src/components/chat/chat-bubble.tsx
@@ -1,22 +1,26 @@
 import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
 import type { ReactNode } from "react";
 
 interface ChatBubbleProps {
   role: string;
   children: ReactNode;
+  layoutId?: string;
 }
 
-export function ChatBubble({ role, children }: ChatBubbleProps) {
+export function ChatBubble({ role, children, layoutId }: ChatBubbleProps) {
   return (
-    <div className={cn("flex", role === "user" ? "justify-end" : "justify-start")}> 
-      <div
+    <div className={cn("flex", role === "user" ? "justify-end" : "justify-start")}>
+      <motion.div
+        layout
+        layoutId={layoutId}
         className={cn(
           "max-w-[80%] break-words whitespace-pre-wrap rounded-lg px-3 py-2 text-sm",
           role === "user" ? "bg-primary text-primary-foreground" : "bg-muted"
         )}
       >
         {children}
-      </div>
+      </motion.div>
     </div>
   );
 }

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -1,5 +1,6 @@
-import { ArrowDown, Loader2 } from "lucide-react";
+import { ArrowDown } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { motion } from "motion/react";
 import { ChatBubble } from "./chat-bubble";
 import type { UIMessage } from "ai";
 
@@ -8,9 +9,27 @@ interface ChatMessagesProps {
   isLoading: boolean;
 }
 
+function AnimatedEllipsis() {
+  return (
+    <span className="inline-flex w-[3ch] justify-center font-bold text-muted-foreground">
+      {[0, 1, 2].map((i) => (
+        <motion.span
+          key={i}
+          className="w-[1ch]"
+          animate={{ opacity: [0, 1, 0] }}
+          transition={{ duration: 0.8, repeat: Infinity, delay: i * 0.15 }}
+        >
+          .
+        </motion.span>
+      ))}
+    </span>
+  );
+}
+
 export function ChatMessages({ messages, isLoading }: ChatMessagesProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isAtBottom, setIsAtBottom] = useState(true);
+  const prevIsLoading = useRef(isLoading);
 
   const scrollToBottom = () => {
     const el = containerRef.current;
@@ -23,7 +42,10 @@ export function ChatMessages({ messages, isLoading }: ChatMessagesProps) {
     if (isAtBottom) {
       scrollToBottom();
     }
-  }, [messages, isAtBottom]);
+  }, [messages, isLoading, isAtBottom]);
+  useEffect(() => {
+    prevIsLoading.current = isLoading;
+  }, [isLoading]);
 
   const handleScroll = () => {
     const el = containerRef.current;
@@ -33,6 +55,15 @@ export function ChatMessages({ messages, isLoading }: ChatMessagesProps) {
     setIsAtBottom(atBottom);
   };
 
+  const displayedMessages: UIMessage[] = [...messages];
+  if (isLoading && displayedMessages[displayedMessages.length - 1]?.role === "assistant") {
+    displayedMessages.pop();
+  }
+  if (isLoading) {
+    displayedMessages.push({ id: "__loading__", role: "assistant", parts: [{ type: "text", text: "" }] });
+  }
+  const justFinishedLoading = !isLoading && prevIsLoading.current;
+
   return (
     <div className="relative flex flex-1 w-full min-h-0">
       <div
@@ -40,16 +71,25 @@ export function ChatMessages({ messages, isLoading }: ChatMessagesProps) {
         onScroll={handleScroll}
         className="chat-scrollbar flex flex-1 min-h-0 flex-col space-y-4 overflow-y-auto overflow-x-hidden py-4"
       >
-        {messages.map((m) => (
-          <ChatBubble key={m.id} role={m.role}>
-            {m.parts.map((p) => (p.type === "text" ? p.text : "")).join("")}
-          </ChatBubble>
-        ))}
-        {isLoading && (
-          <div className="flex justify-center">
-            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-          </div>
-        )}
+        {displayedMessages.map((m, idx) => {
+          const isLoadingBubble = m.id === "__loading__";
+          const isLatestAssistant = m.role === "assistant" && idx === displayedMessages.length - 1;
+          return (
+            <ChatBubble
+              key={m.id}
+              role={m.role}
+              layoutId={
+                isLoadingBubble || (isLatestAssistant && justFinishedLoading)
+                  ? "assistant-bubble"
+                  : undefined
+              }
+            >
+              {isLoadingBubble
+                ? <AnimatedEllipsis />
+                : m.parts.map((p) => (p.type === "text" ? p.text : "")).join("")}
+            </ChatBubble>
+          );
+        })}
       </div>
       {!isAtBottom && (
         <button


### PR DESCRIPTION
## Summary
- animate ellipsis in typing indicator bubble
- use shared layout animation to transition from typing indicator to message
- keep typing indicator width constant by fading dots
- refactor message rendering to append a placeholder assistant bubble and morph it into the final reply, preserving previous bubbles
- make typing indicator ellipsis bold
- speed up ellipsis animation
- retain previous assistant bubble when loading the next reply

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f8f563a4832eb17d481cdcf53ab7