### PR TITLE
Adjust dark theme palette

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -60,38 +60,38 @@ code {
 }
 
 .dark {
-  --background: oklch(0.141 0.005 285.823);
+  --background: oklch(0.2 0.005 285.823);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.141 0.005 285.823);
+  --card: oklch(0.2 0.005 285.823);
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.141 0.005 285.823);
+  --popover: oklch(0.2 0.005 285.823);
   --popover-foreground: oklch(0.985 0 0);
   --primary: oklch(0.769 0.188 70.08);
   --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.32 0.065 70.08);
+  --secondary: oklch(0.38 0.065 70.08);
   --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.29 0.05 70.08);
+  --muted: oklch(0.35 0.05 70.08);
   --muted-foreground: oklch(0.74 0.07 70.08);
-  --accent: oklch(0.45 0.1 70.08);
+  --accent: oklch(0.55 0.1 70.08);
   --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.396 0.141 25.723);
+  --destructive: oklch(0.45 0.141 25.723);
   --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(0.32 0.065 70.08);
-  --input: oklch(0.32 0.065 70.08);
-  --ring: oklch(0.49 0.098 70.08);
-  --chart-1: oklch(0.58 0.2 70.08);
-  --chart-2: oklch(0.46 0.15 70.08);
-  --chart-3: oklch(0.38 0.1 70.08);
-  --chart-4: oklch(0.65 0.16 70.08);
-  --chart-5: oklch(0.52 0.18 70.08);
-  --sidebar: oklch(0.25 0.04 70.08);
+  --border: oklch(0.4 0.065 70.08);
+  --input: oklch(0.4 0.065 70.08);
+  --ring: oklch(0.55 0.098 70.08);
+  --chart-1: oklch(0.65 0.2 70.08);
+  --chart-2: oklch(0.53 0.15 70.08);
+  --chart-3: oklch(0.45 0.1 70.08);
+  --chart-4: oklch(0.72 0.16 70.08);
+  --chart-5: oklch(0.6 0.18 70.08);
+  --sidebar: oklch(0.3 0.04 70.08);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.769 0.188 70.08);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.32 0.065 70.08);
+  --sidebar-accent: oklch(0.38 0.065 70.08);
   --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(0.32 0.065 70.08);
-  --sidebar-ring: oklch(0.49 0.098 70.08);
+  --sidebar-border: oklch(0.38 0.065 70.08);
+  --sidebar-ring: oklch(0.55 0.098 70.08);
 }
 
 @theme inline {


### PR DESCRIPTION
## Summary
- lighten dark theme background and accent colors for better readability

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1095ddd58832eb9239e12237a4722