### PR TITLE
Hide support and feedback mascots on mobile

### DIFF
--- a/src/components/contact-credenza.tsx
+++ b/src/components/contact-credenza.tsx
@@ -25,7 +25,7 @@ export function ContactCredenza({ children }: { children?: React.ReactNode }) {
         <img
           src="/assets/mascot/mascot_detective.png"
           alt="Cat mascot"
-          className="mx-auto my-4 h-40 w-auto"
+          className="mx-auto my-4 hidden h-40 w-auto md:block"
         />
         <CredenzaHeader>
           <CredenzaTitle>{t("contact.title")}</CredenzaTitle>

--- a/src/components/feedback-credenza.tsx
+++ b/src/components/feedback-credenza.tsx
@@ -25,7 +25,7 @@ export function FeedbackCredenza({ children }: { children?: React.ReactNode }) {
         <img
           src="/assets/mascot/mascot_full_body.png"
           alt="Cat mascot"
-          className="mx-auto my-4 h-40 w-auto"
+          className="mx-auto my-4 hidden h-40 w-auto md:block"
         />
         <CredenzaHeader>
           <CredenzaTitle>{t("feedback.title")}</CredenzaTitle>

--- a/src/routes/contact.tsx
+++ b/src/routes/contact.tsx
@@ -16,7 +16,7 @@ function ContactPage() {
           <img
             src="/assets/mascot/mascot_detective.png"
             alt={t("contact.title")}
-            className="w-40"
+            className="hidden w-40 md:block"
           />
           <h1 className="text-3xl font-bold">{t("contact.title")}</h1>
           <p className="text-muted-foreground">{t("contact.description")}</p>

--- a/src/routes/feedback.tsx
+++ b/src/routes/feedback.tsx
@@ -17,7 +17,7 @@ function FeedbackPage() {
           <img
             src="/assets/mascot/mascot_full_body.png"
             alt={t("feedback.title")}
-            className="w-40"
+            className="hidden w-40 md:block"
           />
           <h1 className="text-3xl font-bold">{t("feedback.title")}</h1>
           <p className="text-muted-foreground">{t("feedback.description")}</p>


### PR DESCRIPTION
## Summary
- Hide contact (support) mascot images on small screens in modal and standalone page
- Hide feedback mascot images on small screens in modal and standalone page

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a109ab5274832ea2107092808686f4