### PR TITLE
feat: add project navigation to sidebar

### DIFF
--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -14,6 +14,7 @@ import { FeedbackCredenza } from "@/components/feedback-credenza";
 import { NavMain } from "@/components/sidebar/nav-main";
 import { NavSecondary } from "@/components/sidebar/nav-secondary";
 import { NavUser } from "@/components/sidebar/nav-user";
+import { NavProjects } from "@/components/sidebar/nav-projects";
 import {
   Sidebar,
   SidebarContent,
@@ -74,7 +75,21 @@ const data = {
       ),
     },
   ],
-  projects: [],
+  projects: [
+    {
+      name: "Design Engineering",
+      url: "#",
+    },
+    {
+      name: "Acme Corp",
+      url: "#",
+      badge: "12",
+    },
+    {
+      name: "Internal",
+      url: "#",
+    },
+  ],
 };
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
@@ -98,6 +113,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         </SidebarMenu>
       </SidebarHeader>
       <SidebarContent>
+        <NavProjects projects={data.projects} />
         <NavMain items={data.navMain} />
         <NavSecondary items={data.navSecondary} className="mt-auto" />
       </SidebarContent>

--- a/src/components/sidebar/nav-projects.tsx
+++ b/src/components/sidebar/nav-projects.tsx
@@ -1,0 +1,45 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar";
+
+interface NavProject {
+  name: string;
+  url: string;
+  badge?: string;
+}
+
+interface NavProjectsProps {
+  projects: NavProject[];
+}
+
+export function NavProjects({ projects }: NavProjectsProps) {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>Projects</SidebarGroupLabel>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {projects.map((project) => (
+            <SidebarMenuItem key={project.name}>
+              <SidebarMenuButton asChild>
+                <a href={project.url}>
+                  <span>{project.name}</span>
+                  {project.badge && (
+                    <Badge variant="secondary" className="ml-auto">
+                      {project.badge}
+                    </Badge>
+                  )}
+                </a>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}


### PR DESCRIPTION
## Summary
- add projects navigation section to sidebar
- include sample projects and badge styling

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a10a071410832e98b81cba8068a5b6