### PR TITLE
fix: adjust viewport for iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, height=device-height, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
     <link rel="icon" href="/favicon.ico" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Laranjito - Your Personal Diet Tracker" />

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,12 +6,22 @@
 @custom-variant dark (&:is(.dark *));
 
 body {
-  @apply m-0 h-dvh w-dvw overflow-x-hidden overflow-y-auto;
+  @apply m-0 h-screen h-dvh w-screen w-dvw overflow-x-hidden overflow-y-auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
     "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+@supports (-webkit-touch-callout: none) {
+  html {
+    height: -webkit-fill-available;
+  }
+
+  body {
+    height: -webkit-fill-available;
+  }
 }
 
 #app {


### PR DESCRIPTION
## Summary
- disable iOS auto-zoom and specify device height via meta viewport
- add fallback viewport units for body sizing and use -webkit-fill-available on iOS to avoid extra scroll

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a10ee47f3c832ea6d3334fbed38a06