### PR TITLE
feat: add chat file attachments

### DIFF
--- a/src/components/chat/chat-bubble.tsx
+++ b/src/components/chat/chat-bubble.tsx
@@ -11,7 +11,7 @@ export function ChatBubble({ role, children }: ChatBubbleProps) {
     <div className={cn("flex", role === "user" ? "justify-end" : "justify-start")}> 
       <div
         className={cn(
-          "max-w-[80%] break-words whitespace-pre-wrap rounded-lg px-3 py-2 text-sm",
+          "max-w-[80%] break-words whitespace-pre-wrap rounded-lg px-3 py-2 text-sm space-y-2",
           role === "user" ? "bg-primary text-primary-foreground" : "bg-muted"
         )}
       >

--- a/src/components/chat/chat-bubble.tsx
+++ b/src/components/chat/chat-bubble.tsx
@@ -8,10 +8,10 @@ interface ChatBubbleProps {
 
 export function ChatBubble({ role, children }: ChatBubbleProps) {
   return (
-    <div className={cn("flex", role === "user" ? "justify-end" : "justify-start")}> 
+    <div className={cn("flex", role === "user" ? "justify-end" : "justify-start")}>
       <div
         className={cn(
-          "max-w-[80%] break-words whitespace-pre-wrap rounded-lg px-3 py-2 text-sm space-y-2",
+          "max-w-[80%] break-words whitespace-pre-wrap rounded-lg px-3 py-2 text-sm flex flex-col gap-2",
           role === "user" ? "bg-primary text-primary-foreground" : "bg-muted"
         )}
       >

--- a/src/components/chat/chat-footer.tsx
+++ b/src/components/chat/chat-footer.tsx
@@ -4,7 +4,7 @@ import { PlaceholdersAndVanishInput } from "@/components/ui/placeholders-and-van
 import { cn } from "@/lib/utils";
 
 interface ChatFooterProps {
-  onSubmit: (value: string, files?: File[]) => void;
+  onSubmit: (value: string, files?: FileList) => void;
   disabled: boolean;
   placeholders: string[];
   className?: string;

--- a/src/components/chat/chat-footer.tsx
+++ b/src/components/chat/chat-footer.tsx
@@ -4,7 +4,7 @@ import { PlaceholdersAndVanishInput } from "@/components/ui/placeholders-and-van
 import { cn } from "@/lib/utils";
 
 interface ChatFooterProps {
-  onSubmit: (value: string) => void;
+  onSubmit: (value: string, files?: FileList | null) => void;
   disabled: boolean;
   placeholders: string[];
   className?: string;

--- a/src/components/chat/chat-footer.tsx
+++ b/src/components/chat/chat-footer.tsx
@@ -4,7 +4,7 @@ import { PlaceholdersAndVanishInput } from "@/components/ui/placeholders-and-van
 import { cn } from "@/lib/utils";
 
 interface ChatFooterProps {
-  onSubmit: (value: string, files?: FileList | null) => void;
+  onSubmit: (value: string, files?: File[]) => void;
   disabled: boolean;
   placeholders: string[];
   className?: string;

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -42,7 +42,33 @@ export function ChatMessages({ messages, isLoading }: ChatMessagesProps) {
       >
         {messages.map((m) => (
           <ChatBubble key={m.id} role={m.role}>
-            {m.parts.map((p) => (p.type === "text" ? p.text : "")).join("")}
+            {m.parts.map((p, i) => {
+              if (p.type === "text") return <span key={i}>{p.text}</span>;
+              if (p.type === "file") {
+                if (p.mediaType.startsWith("image/")) {
+                  return (
+                    <img
+                      key={i}
+                      src={p.url}
+                      alt={p.filename ?? "image"}
+                      className="rounded-lg max-w-full"
+                    />
+                  );
+                }
+                return (
+                  <a
+                    key={i}
+                    href={p.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    {p.filename ?? "Download file"}
+                  </a>
+                );
+              }
+              return null;
+            })}
           </ChatBubble>
         ))}
         {isLoading && (

--- a/src/components/chat/chat-messages.tsx
+++ b/src/components/chat/chat-messages.tsx
@@ -42,33 +42,35 @@ export function ChatMessages({ messages, isLoading }: ChatMessagesProps) {
       >
         {messages.map((m) => (
           <ChatBubble key={m.id} role={m.role}>
-            {m.parts.map((p, i) => {
-              if (p.type === "text") return <span key={i}>{p.text}</span>;
-              if (p.type === "file") {
-                if (p.mediaType.startsWith("image/")) {
-                  return (
+            {m.parts
+              .filter((p) => p.type === "file")
+              .map((p, i) => (
+                <div key={`file-${i}`}>
+                  {p.mediaType.startsWith("image/") ? (
                     <img
-                      key={i}
                       src={p.url}
                       alt={p.filename ?? "image"}
                       className="rounded-lg max-w-full"
                     />
-                  );
-                }
-                return (
-                  <a
-                    key={i}
-                    href={p.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline"
-                  >
-                    {p.filename ?? "Download file"}
-                  </a>
-                );
-              }
-              return null;
-            })}
+                  ) : (
+                    <a
+                      href={p.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline"
+                    >
+                      {p.filename ?? "Download file"}
+                    </a>
+                  )}
+                </div>
+              ))}
+            {m.parts
+              .filter((p) => p.type === "text")
+              .map((p, i) => (
+                <div key={`text-${i}`}>
+                  <span>{p.text}</span>
+                </div>
+              ))}
           </ChatBubble>
         ))}
         {isLoading && (

--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -12,12 +12,9 @@ export function Chat() {
   const transport = useMemo(() => new OpenAIChatTransport(), []);
   const { messages, sendMessage, status } = useChat({ transport });
 
-  async function handleSubmit(value: string) {
-    if (!value.trim()) return;
-    await sendMessage({
-      role: "user",
-      parts: [{ type: "text", text: value }],
-    });
+  async function handleSubmit(value: string, files?: FileList | null) {
+    if (!value.trim() && (!files || files.length === 0)) return;
+    await sendMessage({ text: value, files });
   }
 
   const placeholders = [

--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -12,7 +12,7 @@ export function Chat() {
   const transport = useMemo(() => new OpenAIChatTransport(), []);
   const { messages, sendMessage, status } = useChat({ transport });
 
-  async function handleSubmit(value: string, files?: File[]) {
+  async function handleSubmit(value: string, files?: FileList) {
     const uploadFiles = files && files.length > 0 ? files : undefined;
     if (!value.trim() && !uploadFiles) return;
     await sendMessage({ text: value, files: uploadFiles });

--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -13,8 +13,9 @@ export function Chat() {
   const { messages, sendMessage, status } = useChat({ transport });
 
   async function handleSubmit(value: string, files?: FileList | null) {
-    if (!value.trim() && (!files || files.length === 0)) return;
-    await sendMessage({ text: value, files });
+    const uploadFiles = files ?? undefined;
+    if (!value.trim() && (!uploadFiles || uploadFiles.length === 0)) return;
+    await sendMessage({ text: value, files: uploadFiles });
   }
 
   const placeholders = [

--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -12,9 +12,9 @@ export function Chat() {
   const transport = useMemo(() => new OpenAIChatTransport(), []);
   const { messages, sendMessage, status } = useChat({ transport });
 
-  async function handleSubmit(value: string, files?: FileList | null) {
-    const uploadFiles = files ?? undefined;
-    if (!value.trim() && (!uploadFiles || uploadFiles.length === 0)) return;
+  async function handleSubmit(value: string, files?: File[]) {
+    const uploadFiles = files && files.length > 0 ? files : undefined;
+    if (!value.trim() && !uploadFiles) return;
     await sendMessage({ text: value, files: uploadFiles });
   }
 

--- a/src/components/ui/placeholders-and-vanish-input.tsx
+++ b/src/components/ui/placeholders-and-vanish-input.tsx
@@ -238,7 +238,7 @@ export function PlaceholdersAndVanishInput({
         type="text"
         disabled={disabled}
         className={cn(
-          "relative z-50 h-full w-full rounded-full border-none bg-transparent pl-12 pr-20 sm:pl-16 text-sm sm:text-base text-foreground selection:bg-primary selection:text-primary-foreground focus:outline-none focus:ring-0",
+          "relative z-0 h-full w-full rounded-full border-none bg-transparent pl-12 pr-20 sm:pl-16 text-sm sm:text-base text-foreground selection:bg-primary selection:text-primary-foreground focus:outline-none focus:ring-0",
           animating && "text-transparent"
         )}
       />

--- a/src/components/ui/placeholders-and-vanish-input.tsx
+++ b/src/components/ui/placeholders-and-vanish-input.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge";
 
 interface PlaceholdersAndVanishInputProps {
   placeholders: string[];
-  onSubmit: (value: string, files?: File[]) => void;
+  onSubmit: (value: string, files?: FileList) => void;
   disabled?: boolean;
 }
 
@@ -53,6 +53,12 @@ export function PlaceholdersAndVanishInput({
   const [animating, setAnimating] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [files, setFiles] = useState<File[]>([]);
+
+  const toFileList = (fileArray: File[]): FileList => {
+    const dataTransfer = new DataTransfer();
+    fileArray.forEach((file) => dataTransfer.items.add(file));
+    return dataTransfer.files;
+  };
 
   const draw = useCallback(() => {
     if (!inputRef.current) return;
@@ -182,7 +188,8 @@ export function PlaceholdersAndVanishInput({
       setValue("");
     }
 
-    onSubmit(currentValue, files);
+    const fileList = files.length > 0 ? toFileList(files) : undefined;
+    onSubmit(currentValue, fileList);
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }

--- a/src/lib/openai-chat-transport.ts
+++ b/src/lib/openai-chat-transport.ts
@@ -13,9 +13,15 @@ export class OpenAIChatTransport extends HttpChatTransport<UIMessage> {
             ...body,
             messages: messages.map((m) => ({
               role: m.role,
-              content: m.parts
-                .map((p) => (p.type === "text" ? p.text : ""))
-                .join(""),
+              content: m.parts.map((p) => {
+                if (p.type === "text") {
+                  return { type: "text", text: p.text };
+                }
+                if (p.type === "file" && p.mediaType.startsWith("image/")) {
+                  return { type: "image_url", image_url: { url: p.url } };
+                }
+                return { type: "text", text: "" };
+              }),
             })),
           },
         };


### PR DESCRIPTION
## Summary
- add file picker to chat input
- send selected files with messages and render attachments
- support image uploads in OpenAI transport

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1195082e0832e8558891e49ca3b2d