### PR TITLE
feat: add account settings page

### DIFF
--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -5,6 +5,7 @@ import {
   LifeBuoy,
   Send,
   Bot,
+  Settings,
   type LucideIcon,
 } from "lucide-react";
 
@@ -46,6 +47,11 @@ const data = {
           url: "/home",
         },
       ],
+    },
+    {
+      title: "Settings",
+      url: "/settings",
+      icon: Settings,
     },
   ],
   navSecondary: [

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as _authenticatedLayoutRouteImport } from './routes/__authenticat
 import { Route as _authenticatedLayoutIndexRouteImport } from './routes/__authenticatedLayout/index'
 import { Route as _authenticationLayoutRegisterRouteImport } from './routes/__authenticationLayout/register'
 import { Route as _authenticationLayoutLoginRouteImport } from './routes/__authenticationLayout/login'
+import { Route as _authenticatedLayoutSettingsRouteImport } from './routes/__authenticatedLayout/settings'
 import { Route as _authenticatedLayoutHomeRouteImport } from './routes/__authenticatedLayout/home'
 import { Route as _authenticatedLayoutChatRouteImport } from './routes/__authenticatedLayout/chat'
 
@@ -67,6 +68,12 @@ const _authenticationLayoutLoginRoute =
     path: '/login',
     getParentRoute: () => _authenticationLayoutRoute,
   } as any)
+const _authenticatedLayoutSettingsRoute =
+  _authenticatedLayoutSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => _authenticatedLayoutRoute,
+  } as any)
 const _authenticatedLayoutHomeRoute =
   _authenticatedLayoutHomeRouteImport.update({
     id: '/home',
@@ -87,6 +94,7 @@ export interface FileRoutesByFullPath {
   '/waitlist-drawer-test': typeof WaitlistDrawerTestRoute
   '/chat': typeof _authenticatedLayoutChatRoute
   '/home': typeof _authenticatedLayoutHomeRoute
+  '/settings': typeof _authenticatedLayoutSettingsRoute
   '/login': typeof _authenticationLayoutLoginRoute
   '/register': typeof _authenticationLayoutRegisterRoute
   '/': typeof _authenticatedLayoutIndexRoute
@@ -98,6 +106,7 @@ export interface FileRoutesByTo {
   '/waitlist-drawer-test': typeof WaitlistDrawerTestRoute
   '/chat': typeof _authenticatedLayoutChatRoute
   '/home': typeof _authenticatedLayoutHomeRoute
+  '/settings': typeof _authenticatedLayoutSettingsRoute
   '/login': typeof _authenticationLayoutLoginRoute
   '/register': typeof _authenticationLayoutRegisterRoute
   '/': typeof _authenticatedLayoutIndexRoute
@@ -112,6 +121,7 @@ export interface FileRoutesById {
   '/waitlist-drawer-test': typeof WaitlistDrawerTestRoute
   '/__authenticatedLayout/chat': typeof _authenticatedLayoutChatRoute
   '/__authenticatedLayout/home': typeof _authenticatedLayoutHomeRoute
+  '/__authenticatedLayout/settings': typeof _authenticatedLayoutSettingsRoute
   '/__authenticationLayout/login': typeof _authenticationLayoutLoginRoute
   '/__authenticationLayout/register': typeof _authenticationLayoutRegisterRoute
   '/__authenticatedLayout/': typeof _authenticatedLayoutIndexRoute
@@ -125,6 +135,7 @@ export interface FileRouteTypes {
     | '/waitlist-drawer-test'
     | '/chat'
     | '/home'
+    | '/settings'
     | '/login'
     | '/register'
     | '/'
@@ -136,6 +147,7 @@ export interface FileRouteTypes {
     | '/waitlist-drawer-test'
     | '/chat'
     | '/home'
+    | '/settings'
     | '/login'
     | '/register'
     | '/'
@@ -149,6 +161,7 @@ export interface FileRouteTypes {
     | '/waitlist-drawer-test'
     | '/__authenticatedLayout/chat'
     | '/__authenticatedLayout/home'
+    | '/__authenticatedLayout/settings'
     | '/__authenticationLayout/login'
     | '/__authenticationLayout/register'
     | '/__authenticatedLayout/'
@@ -228,6 +241,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof _authenticationLayoutLoginRouteImport
       parentRoute: typeof _authenticationLayoutRoute
     }
+    '/__authenticatedLayout/settings': {
+      id: '/__authenticatedLayout/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof _authenticatedLayoutSettingsRouteImport
+      parentRoute: typeof _authenticatedLayoutRoute
+    }
     '/__authenticatedLayout/home': {
       id: '/__authenticatedLayout/home'
       path: '/home'
@@ -248,12 +268,14 @@ declare module '@tanstack/react-router' {
 interface _authenticatedLayoutRouteChildren {
   _authenticatedLayoutChatRoute: typeof _authenticatedLayoutChatRoute
   _authenticatedLayoutHomeRoute: typeof _authenticatedLayoutHomeRoute
+  _authenticatedLayoutSettingsRoute: typeof _authenticatedLayoutSettingsRoute
   _authenticatedLayoutIndexRoute: typeof _authenticatedLayoutIndexRoute
 }
 
 const _authenticatedLayoutRouteChildren: _authenticatedLayoutRouteChildren = {
   _authenticatedLayoutChatRoute: _authenticatedLayoutChatRoute,
   _authenticatedLayoutHomeRoute: _authenticatedLayoutHomeRoute,
+  _authenticatedLayoutSettingsRoute: _authenticatedLayoutSettingsRoute,
   _authenticatedLayoutIndexRoute: _authenticatedLayoutIndexRoute,
 }
 

--- a/src/routes/__authenticatedLayout/settings.tsx
+++ b/src/routes/__authenticatedLayout/settings.tsx
@@ -1,0 +1,411 @@
+import { useEffect } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { account } from "@/lib/appwrite";
+import useSession from "@/hooks/queries/user";
+import { toast } from "sonner";
+
+export const Route = createFileRoute("/__authenticatedLayout/settings")({
+  component: SettingsPage,
+});
+
+function SettingsPage() {
+  const queryClient = useQueryClient();
+  const { data: session } = useSession();
+
+  // Update Name
+  const nameSchema = z.object({ name: z.string().min(1) });
+  const nameForm = useForm<{ name: string }>({
+    resolver: zodResolver(nameSchema),
+    defaultValues: { name: session?.name ?? "" },
+  });
+  useEffect(() => {
+    nameForm.reset({ name: session?.name ?? "" });
+  }, [session]);
+  const nameMutation = useMutation({
+    mutationFn: ({ name }: { name: string }) => account.updateName(name),
+    onSuccess: (_, values) => {
+      queryClient.setQueryData(["session"], (old: any) => ({ ...old, name: values.name }));
+      toast.success("Name updated");
+    },
+    onError: (err: any) => toast.error(err.message),
+  });
+
+  // Update Email
+  const emailSchema = z.object({
+    email: z.string().email(),
+    password: z.string().min(1),
+  });
+  const emailForm = useForm<{ email: string; password: string }>({
+    resolver: zodResolver(emailSchema),
+    defaultValues: { email: session?.email ?? "", password: "" },
+  });
+  useEffect(() => {
+    emailForm.reset({ email: session?.email ?? "", password: "" });
+  }, [session]);
+  const emailMutation = useMutation({
+    mutationFn: ({ email, password }: { email: string; password: string }) =>
+      account.updateEmail(email, password),
+    onSuccess: (_, values) => {
+      queryClient.setQueryData(["session"], (old: any) => ({ ...old, email: values.email }));
+      toast.success("Email updated");
+    },
+    onError: (err: any) => toast.error(err.message),
+  });
+
+  // Update Password
+  const passwordSchema = z.object({
+    oldPassword: z.string().min(1),
+    password: z.string().min(8),
+  });
+  const passwordForm = useForm<{ oldPassword: string; password: string }>({
+    resolver: zodResolver(passwordSchema),
+    defaultValues: { oldPassword: "", password: "" },
+  });
+  const passwordMutation = useMutation({
+    mutationFn: ({ password, oldPassword }: { password: string; oldPassword: string }) =>
+      account.updatePassword(password, oldPassword),
+    onSuccess: () => {
+      toast.success("Password updated");
+      passwordForm.reset();
+    },
+    onError: (err: any) => toast.error(err.message),
+  });
+
+  // Update Phone
+  const phoneSchema = z.object({
+    phone: z.string().min(1),
+    password: z.string().min(1),
+  });
+  const phoneForm = useForm<{ phone: string; password: string }>({
+    resolver: zodResolver(phoneSchema),
+    defaultValues: { phone: session?.phone ?? "", password: "" },
+  });
+  useEffect(() => {
+    phoneForm.reset({ phone: session?.phone ?? "", password: "" });
+  }, [session]);
+  const phoneMutation = useMutation({
+    mutationFn: ({ phone, password }: { phone: string; password: string }) =>
+      account.updatePhone(phone, password),
+    onSuccess: () => {
+      toast.success("Phone updated");
+      phoneForm.reset({ phone: "", password: "" });
+      queryClient.invalidateQueries({ queryKey: ["session"] });
+    },
+    onError: (err: any) => toast.error(err.message),
+  });
+
+  // Update Preferences
+  const prefsSchema = z.object({
+    language: z.string().min(1),
+    newsletter: z.boolean().optional(),
+  });
+  const prefsForm = useForm<{ language: string; newsletter?: boolean }>({
+    resolver: zodResolver(prefsSchema),
+    defaultValues: {
+      language: (session?.prefs as any)?.language ?? "",
+      newsletter: (session?.prefs as any)?.newsletter ?? false,
+    },
+  });
+  useEffect(() => {
+    prefsForm.reset({
+      language: (session?.prefs as any)?.language ?? "",
+      newsletter: (session?.prefs as any)?.newsletter ?? false,
+    });
+  }, [session]);
+  const prefsMutation = useMutation({
+    mutationFn: ({ language, newsletter }: { language: string; newsletter?: boolean }) =>
+      account.updatePrefs({ language, newsletter }),
+    onSuccess: (_, values) => {
+      queryClient.setQueryData(["session"], (old: any) => ({
+        ...old,
+        prefs: { ...(old?.prefs ?? {}), language: values.language, newsletter: values.newsletter },
+      }));
+      toast.success("Preferences updated");
+    },
+    onError: (err: any) => toast.error(err.message),
+  });
+
+  // Sessions
+  const { data: sessionsData, refetch: refetchSessions } = useQuery({
+    queryKey: ["sessions"],
+    queryFn: async () => (await account.listSessions()).sessions,
+  });
+  const deleteSessionMutation = useMutation({
+    mutationFn: (id: string) => account.deleteSession(id),
+    onSuccess: () => {
+      toast.success("Session removed");
+      refetchSessions();
+    },
+    onError: (err: any) => toast.error(err.message),
+  });
+  const deleteAllSessionsMutation = useMutation({
+    mutationFn: () => account.deleteSessions(),
+    onSuccess: () => {
+      toast.success("All sessions removed");
+      refetchSessions();
+    },
+    onError: (err: any) => toast.error(err.message),
+  });
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Update Name</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form {...nameForm}>
+            <form
+              className="space-y-4"
+              onSubmit={nameForm.handleSubmit((v) => nameMutation.mutate(v))}
+            >
+              <FormField
+                control={nameForm.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Button type="submit" loading={nameMutation.status === "pending"}>
+                Save
+              </Button>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Update Email</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form {...emailForm}>
+            <form
+              className="space-y-4"
+              onSubmit={emailForm.handleSubmit((v) => emailMutation.mutate(v))}
+            >
+              <FormField
+                control={emailForm.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={emailForm.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Password</FormLabel>
+                    <FormControl>
+                      <Input type="password" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Button type="submit" loading={emailMutation.status === "pending"}>
+                Save
+              </Button>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Update Password</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form {...passwordForm}>
+            <form
+              className="space-y-4"
+              onSubmit={passwordForm.handleSubmit((v) => passwordMutation.mutate(v))}
+            >
+              <FormField
+                control={passwordForm.control}
+                name="oldPassword"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Current Password</FormLabel>
+                    <FormControl>
+                      <Input type="password" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={passwordForm.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>New Password</FormLabel>
+                    <FormControl>
+                      <Input type="password" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Button type="submit" loading={passwordMutation.status === "pending"}>
+                Save
+              </Button>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Update Phone</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form {...phoneForm}>
+            <form
+              className="space-y-4"
+              onSubmit={phoneForm.handleSubmit((v) => phoneMutation.mutate(v))}
+            >
+              <FormField
+                control={phoneForm.control}
+                name="phone"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Phone</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={phoneForm.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Password</FormLabel>
+                    <FormControl>
+                      <Input type="password" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Button type="submit" loading={phoneMutation.status === "pending"}>
+                Save
+              </Button>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Preferences</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form {...prefsForm}>
+            <form
+              className="space-y-4"
+              onSubmit={prefsForm.handleSubmit((v) => prefsMutation.mutate(v))}
+            >
+              <FormField
+                control={prefsForm.control}
+                name="language"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Language</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={prefsForm.control}
+                name="newsletter"
+                render={({ field }) => (
+                  <FormItem className="flex items-center gap-2">
+                    <FormControl>
+                      <input
+                        type="checkbox"
+                        checked={field.value}
+                        onChange={(e) => field.onChange(e.target.checked)}
+                      />
+                    </FormControl>
+                    <FormLabel className="!mt-0">Newsletter</FormLabel>
+                  </FormItem>
+                )}
+              />
+              <Button type="submit" loading={prefsMutation.status === "pending"}>
+                Save
+              </Button>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Sessions</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {sessionsData?.map((s) => (
+            <div key={s.$id} className="flex items-center justify-between border-b pb-2">
+              <div>
+                <p className="text-sm">{s.clientName} - {s.osName}</p>
+                <p className="text-xs text-muted-foreground">{new Date(s.expire).toLocaleString()}</p>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => deleteSessionMutation.mutate(s.$id)}
+              >
+                Revoke
+              </Button>
+            </div>
+          ))}
+          {sessionsData && sessionsData.length > 0 && (
+            <Button
+              variant="destructive"
+              loading={deleteAllSessionsMutation.status === "pending"}
+              onClick={() => deleteAllSessionsMutation.mutate()}
+            >
+              Revoke All Sessions
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default SettingsPage;
+


### PR DESCRIPTION
## Summary
- add settings link in sidebar
- implement account settings page for updating profile fields and managing sessions

## Testing
- `pnpm test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a11b3d3a6c832ea3f3a178e661f81f