### PR TITLE
feat: add password recovery via email OTP

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "eventsource-parser": "^1.1.2",
+    "input-otp": "^1.4.2",
     "lucide-react": "^0.476.0",
     "motion": "^12.23.12",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       eventsource-parser:
         specifier: ^1.1.2
         version: 1.1.2
+      input-otp:
+        specifier: ^1.4.2
+        version: 1.4.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       lucide-react:
         specifier: ^0.476.0
         version: 0.476.0(react@19.1.1)
@@ -1637,6 +1640,12 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  input-otp@1.4.2:
+    resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -3751,6 +3760,11 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  input-otp@1.4.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
 
   is-arrayish@0.2.1: {}
 

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+import {
+  OTPInput as BaseOTPInput,
+  OTPInputContext,
+} from "input-otp";
+import type { SlotProps } from "input-otp";
+import { cn } from "@/lib/utils";
+
+const InputOTP = React.forwardRef<
+  React.ElementRef<typeof BaseOTPInput>,
+  React.ComponentPropsWithoutRef<typeof BaseOTPInput>
+>(({ className, ...props }, ref) => (
+  <BaseOTPInput
+    ref={ref}
+    className={cn("flex gap-2", className)}
+    {...props}
+  />
+));
+InputOTP.displayName = "InputOTP";
+
+const InputOTPGroup = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex gap-2", className)} {...props} />
+));
+InputOTPGroup.displayName = "InputOTPGroup";
+
+const InputOTPSeparator = React.forwardRef<
+  HTMLSpanElement,
+  React.HTMLAttributes<HTMLSpanElement>
+>(({ className, ...props }, ref) => (
+  <span ref={ref} className={cn("px-2", className)} {...props} />
+));
+InputOTPSeparator.displayName = "InputOTPSeparator";
+
+const InputOTPSlot = React.forwardRef<
+  HTMLDivElement,
+  { index: number } & React.HTMLAttributes<HTMLDivElement>
+>(({ index, className, ...props }, ref) => {
+  const context = React.useContext(OTPInputContext);
+  const slot: SlotProps = context.slots[index];
+  const { char, hasFakeCaret, isActive } = slot;
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "relative flex h-10 w-10 items-center justify-center rounded-md border border-input text-sm transition-all",
+        isActive && "z-10 ring-2 ring-ring ring-offset-background",
+        className
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="h-4 w-px animate-caret-blink bg-foreground" />
+        </div>
+      )}
+    </div>
+  );
+});
+InputOTPSlot.displayName = "InputOTPSlot";
+
+export { InputOTP, InputOTPGroup, InputOTPSeparator, InputOTPSlot };

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as _authenticationLayoutRouteImport } from './routes/__authentica
 import { Route as _authenticatedLayoutRouteImport } from './routes/__authenticatedLayout'
 import { Route as _authenticatedLayoutIndexRouteImport } from './routes/__authenticatedLayout/index'
 import { Route as _authenticationLayoutRegisterRouteImport } from './routes/__authenticationLayout/register'
+import { Route as _authenticationLayoutRecoverRouteImport } from './routes/__authenticationLayout/recover'
 import { Route as _authenticationLayoutLoginRouteImport } from './routes/__authenticationLayout/login'
 import { Route as _authenticatedLayoutHomeRouteImport } from './routes/__authenticatedLayout/home'
 import { Route as _authenticatedLayoutChatRouteImport } from './routes/__authenticatedLayout/chat'
@@ -61,6 +62,12 @@ const _authenticationLayoutRegisterRoute =
     path: '/register',
     getParentRoute: () => _authenticationLayoutRoute,
   } as any)
+const _authenticationLayoutRecoverRoute =
+  _authenticationLayoutRecoverRouteImport.update({
+    id: '/recover',
+    path: '/recover',
+    getParentRoute: () => _authenticationLayoutRoute,
+  } as any)
 const _authenticationLayoutLoginRoute =
   _authenticationLayoutLoginRouteImport.update({
     id: '/login',
@@ -88,6 +95,7 @@ export interface FileRoutesByFullPath {
   '/chat': typeof _authenticatedLayoutChatRoute
   '/home': typeof _authenticatedLayoutHomeRoute
   '/login': typeof _authenticationLayoutLoginRoute
+  '/recover': typeof _authenticationLayoutRecoverRoute
   '/register': typeof _authenticationLayoutRegisterRoute
   '/': typeof _authenticatedLayoutIndexRoute
 }
@@ -99,6 +107,7 @@ export interface FileRoutesByTo {
   '/chat': typeof _authenticatedLayoutChatRoute
   '/home': typeof _authenticatedLayoutHomeRoute
   '/login': typeof _authenticationLayoutLoginRoute
+  '/recover': typeof _authenticationLayoutRecoverRoute
   '/register': typeof _authenticationLayoutRegisterRoute
   '/': typeof _authenticatedLayoutIndexRoute
 }
@@ -113,6 +122,7 @@ export interface FileRoutesById {
   '/__authenticatedLayout/chat': typeof _authenticatedLayoutChatRoute
   '/__authenticatedLayout/home': typeof _authenticatedLayoutHomeRoute
   '/__authenticationLayout/login': typeof _authenticationLayoutLoginRoute
+  '/__authenticationLayout/recover': typeof _authenticationLayoutRecoverRoute
   '/__authenticationLayout/register': typeof _authenticationLayoutRegisterRoute
   '/__authenticatedLayout/': typeof _authenticatedLayoutIndexRoute
 }
@@ -126,6 +136,7 @@ export interface FileRouteTypes {
     | '/chat'
     | '/home'
     | '/login'
+    | '/recover'
     | '/register'
     | '/'
   fileRoutesByTo: FileRoutesByTo
@@ -137,6 +148,7 @@ export interface FileRouteTypes {
     | '/chat'
     | '/home'
     | '/login'
+    | '/recover'
     | '/register'
     | '/'
   id:
@@ -150,6 +162,7 @@ export interface FileRouteTypes {
     | '/__authenticatedLayout/chat'
     | '/__authenticatedLayout/home'
     | '/__authenticationLayout/login'
+    | '/__authenticationLayout/recover'
     | '/__authenticationLayout/register'
     | '/__authenticatedLayout/'
   fileRoutesById: FileRoutesById
@@ -221,6 +234,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof _authenticationLayoutRegisterRouteImport
       parentRoute: typeof _authenticationLayoutRoute
     }
+    '/__authenticationLayout/recover': {
+      id: '/__authenticationLayout/recover'
+      path: '/recover'
+      fullPath: '/recover'
+      preLoaderRoute: typeof _authenticationLayoutRecoverRouteImport
+      parentRoute: typeof _authenticationLayoutRoute
+    }
     '/__authenticationLayout/login': {
       id: '/__authenticationLayout/login'
       path: '/login'
@@ -262,11 +282,13 @@ const _authenticatedLayoutRouteWithChildren =
 
 interface _authenticationLayoutRouteChildren {
   _authenticationLayoutLoginRoute: typeof _authenticationLayoutLoginRoute
+  _authenticationLayoutRecoverRoute: typeof _authenticationLayoutRecoverRoute
   _authenticationLayoutRegisterRoute: typeof _authenticationLayoutRegisterRoute
 }
 
 const _authenticationLayoutRouteChildren: _authenticationLayoutRouteChildren = {
   _authenticationLayoutLoginRoute: _authenticationLayoutLoginRoute,
+  _authenticationLayoutRecoverRoute: _authenticationLayoutRecoverRoute,
   _authenticationLayoutRegisterRoute: _authenticationLayoutRegisterRoute,
 }
 

--- a/src/routes/__authenticationLayout/login.tsx
+++ b/src/routes/__authenticationLayout/login.tsx
@@ -61,6 +61,15 @@ function RouteComponent() {
                   </div>
                   <EmailAndPasswordForm />
                   <div className="text-center text-sm">
+                    {t("login.forgotPassword")}{" "}
+                    <Link
+                      to="/recover"
+                      className="underline underline-offset-4"
+                    >
+                      {t("login.recoverPassword")}
+                    </Link>
+                  </div>
+                  <div className="text-center text-sm">
                     {t("login.dontHaveAccount")}{" "}
                     <Link
                       to="/register"

--- a/src/routes/__authenticationLayout/recover.tsx
+++ b/src/routes/__authenticationLayout/recover.tsx
@@ -1,124 +1,223 @@
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from "@/components/ui/input-otp";
+import { Input } from "@/components/ui/input";
 import { account } from "@/lib/appwrite";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useTranslate } from "@tolgee/react";
+import { useMutation } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
 import { useState } from "react";
-
-interface RecoverSearch {
-  userId?: string;
-  secret?: string;
-}
 
 export const Route = createFileRoute("/__authenticationLayout/recover")({
   component: RecoverPage,
-  validateSearch: (search: Record<string, unknown>): RecoverSearch => {
-    return {
-      userId: search.userId as string | undefined,
-      secret: search.secret as string | undefined,
-    };
-  },
 });
 
 function RecoverPage() {
   const { t } = useTranslate();
-  const [email, setEmail] = useState("");
-  const search = Route.useSearch();
-  const [linkSent, setLinkSent] = useState(false);
-  const [password, setPassword] = useState("");
-  const [passwordAgain, setPasswordAgain] = useState("");
-  const [success, setSuccess] = useState(false);
+  const navigate = useNavigate({ from: "/recover" });
+  const [userId, setUserId] = useState<string | null>(null);
+  const [step, setStep] = useState<"email" | "reset">("email");
 
-  const sendLink = async (e: React.FormEvent) => {
-    e.preventDefault();
-    try {
-      await account.createRecovery(email, `${window.location.origin}/recover`);
-      setLinkSent(true);
-    } catch (err) {
-      console.error(err);
-    }
-  };
+  const emailSchema = z.object({
+    email: z
+      .string()
+      .nonempty({ message: t("validation.required") })
+      .refine((val) => z.email().safeParse(val).success, {
+        message: t("validation.invalidEmail"),
+      }),
+  });
 
-  const resetPassword = async (e: React.FormEvent) => {
-    e.preventDefault();
-    try {
-      if (password !== passwordAgain) return;
-      await account.updateRecovery(search.userId!, search.secret!, password);
-      setSuccess(true);
-    } catch (err) {
-      console.error(err);
-    }
-  };
+  type EmailFormValues = z.infer<typeof emailSchema>;
+
+  const emailForm = useForm<EmailFormValues>({
+    resolver: zodResolver(emailSchema),
+    defaultValues: { email: "" },
+  });
+
+  const { mutate: sendCode, isPending: sending } = useMutation({
+    mutationFn: (data: EmailFormValues) =>
+      account.createRecovery(data.email, `${window.location.origin}/recover`),
+    onSuccess: (res) => {
+      setUserId(res.userId);
+      setStep("reset");
+      toast.success(t("recover.emailSent"));
+    },
+    onError: (err: any) => toast.error(err.message),
+  });
+
+  const resetSchema = z
+    .object({
+      code: z.string().min(1, { message: t("validation.required") }),
+      password: z
+        .string()
+        .nonempty({ message: t("validation.required") })
+        .min(8, { message: t("validation.passwordMin", { count: 8 }) }),
+      confirmPassword: z
+        .string()
+        .nonempty({ message: t("validation.required") })
+        .min(8, { message: t("validation.passwordMin", { count: 8 }) }),
+    })
+    .refine((data) => data.password === data.confirmPassword, {
+      path: ["confirmPassword"],
+      message: t("recover.passwordMismatch"),
+    });
+
+  type ResetFormValues = z.infer<typeof resetSchema>;
+
+  const resetForm = useForm<ResetFormValues>({
+    resolver: zodResolver(resetSchema),
+    defaultValues: { code: "", password: "", confirmPassword: "" },
+  });
+
+  const { mutate: resetPassword, isPending: resetting } = useMutation({
+    mutationFn: (data: ResetFormValues) =>
+      account.updateRecovery(userId!, data.code, data.password),
+    onSuccess: () => {
+      toast.success(t("recover.success"));
+      navigate({ to: "/login" });
+    },
+    onError: (err: any) => toast.error(err.message),
+  });
 
   return (
     <div className="flex min-h-dvh flex-col items-center justify-center bg-muted py-6 md:py-10">
       <div className="w-full max-w-sm md:max-w-3xl">
-        <div className="flex flex-col gap-6">
-          <Card className="overflow-hidden">
-            <CardContent className="grid p-0 md:grid-cols-2">
-              <div className="p-6 md:p-8">
-                <div className="flex flex-col gap-6">
-                  <div className="flex flex-col items-center text-center">
-                    <h1 className="text-2xl font-bold">
-                      {t("recover.title")}
-                    </h1>
-                  </div>
-                  {!search.userId && !search.secret && !linkSent && !success && (
-                    <form onSubmit={sendLink} className="flex flex-col gap-4">
-                      <Input
-                        type="email"
-                        placeholder={t("login.email-placeholder")}
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
-                      />
-                      <Button type="submit">{t("recover.sendEmail")}</Button>
-                    </form>
-                  )}
-                  {linkSent && !search.userId && !search.secret && !success && (
-                    <div className="text-center text-sm">
-                      <p>{t("recover.emailSent")}</p>
-                    </div>
-                  )}
-                  {search.userId && search.secret && !success && (
-                    <form onSubmit={resetPassword} className="flex flex-col gap-4">
-                      <Input
-                        type="password"
-                        placeholder={t("recover.newPassword")}
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                      />
-                      <Input
-                        type="password"
-                        placeholder={t("recover.confirmPassword")}
-                        value={passwordAgain}
-                        onChange={(e) => setPasswordAgain(e.target.value)}
-                      />
-                      <Button type="submit">{t("recover.submit")}</Button>
-                    </form>
-                  )}
-                  {success && (
-                    <div className="text-center text-sm">
-                      <p>{t("recover.success")}</p>
-                      <Link
-                        to="/login"
-                        className="underline underline-offset-4"
-                      >
-                        {t("recover.backToLogin")}
-                      </Link>
-                    </div>
-                  )}
-                </div>
+        <div className="grid rounded-lg bg-background md:grid-cols-2">
+          <div className="p-6 md:p-8">
+            <div className="flex flex-col gap-6">
+              <div className="flex flex-col items-center text-center">
+                <h1 className="text-2xl font-bold">{t("recover.title")}</h1>
               </div>
-              <div className="relative hidden bg-background md:flex md:items-center md:justify-center">
-                <img
-                  src="/assets/mascot/mascot_worried_face.png"
-                  alt={t("recover.title")}
-                  className="w-60 object-contain"
-                />
-              </div>
-            </CardContent>
-          </Card>
+              {step === "email" && (
+                <Form {...emailForm}>
+                  <form
+                    onSubmit={emailForm.handleSubmit((values) => sendCode(values))}
+                    className="flex flex-col gap-4"
+                  >
+                    <FormField
+                      control={emailForm.control}
+                      name="email"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>{t("login.email")}</FormLabel>
+                          <FormControl>
+                            <Input
+                              type="email"
+                              placeholder={t("login.email-placeholder")}
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <Button
+                      type="submit"
+                      loading={sending ? `${t("feedback.loading")}...` : undefined}
+                    >
+                      {t("recover.sendCode")}
+                    </Button>
+                  </form>
+                </Form>
+              )}
+              {step === "reset" && (
+                <Form {...resetForm}>
+                  <form
+                    onSubmit={resetForm.handleSubmit((values) => resetPassword(values))}
+                    className="flex flex-col gap-4"
+                  >
+                    <FormField
+                      control={resetForm.control}
+                      name="code"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>{t("recover.code")}</FormLabel>
+                          <FormControl>
+                            <InputOTP
+                              maxLength={6}
+                              value={field.value}
+                              onChange={field.onChange}
+                            >
+                              <InputOTPGroup>
+                                {Array.from({ length: 6 }).map((_, i) => (
+                                  <InputOTPSlot key={i} index={i} />
+                                ))}
+                              </InputOTPGroup>
+                            </InputOTP>
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={resetForm.control}
+                      name="password"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>{t("recover.newPassword")}</FormLabel>
+                          <FormControl>
+                            <Input
+                              type="password"
+                              placeholder={t("recover.newPassword")}
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={resetForm.control}
+                      name="confirmPassword"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>{t("recover.confirmPassword")}</FormLabel>
+                          <FormControl>
+                            <Input
+                              type="password"
+                              placeholder={t("recover.confirmPassword")}
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <Button
+                      type="submit"
+                      loading={
+                        resetting ? `${t("feedback.loading")}...` : undefined
+                      }
+                    >
+                      {t("recover.submit")}
+                    </Button>
+                  </form>
+                </Form>
+              )}
+            </div>
+          </div>
+          <div className="relative hidden bg-background md:flex md:items-center md:justify-center">
+            <img
+              src="/assets/mascot/mascot_worried_face.png"
+              alt={t("recover.title")}
+              className="w-60 object-contain"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -126,3 +225,4 @@ function RecoverPage() {
 }
 
 export default RecoverPage;
+

--- a/src/routes/__authenticationLayout/recover.tsx
+++ b/src/routes/__authenticationLayout/recover.tsx
@@ -1,0 +1,141 @@
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSeparator,
+  InputOTPSlot,
+} from "@/components/ui/input-otp";
+import { account } from "@/lib/appwrite";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useTranslate } from "@tolgee/react";
+import { useState } from "react";
+
+export const Route = createFileRoute("/__authenticationLayout/recover")({
+  component: RecoverPage,
+});
+
+function RecoverPage() {
+  const { t } = useTranslate();
+  const [email, setEmail] = useState("");
+  const [otpSent, setOtpSent] = useState(false);
+  const [userId, setUserId] = useState("");
+  const [otp, setOtp] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordAgain, setPasswordAgain] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  const sendCode = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const res = await account.createRecovery(
+        email,
+        `${window.location.origin}/recover`
+      );
+      setUserId(res.userId);
+      setOtpSent(true);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const resetPassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      if (password !== passwordAgain) return;
+      await account.updateRecovery(userId, otp, password);
+      setSuccess(true);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-muted py-6 md:py-10">
+      <div className="w-full max-w-sm md:max-w-3xl">
+        <div className="flex flex-col gap-6">
+          <Card className="overflow-hidden">
+            <CardContent className="grid p-0 md:grid-cols-2">
+              <div className="p-6 md:p-8">
+                <div className="flex flex-col gap-6">
+                  <div className="flex flex-col items-center text-center">
+                    <h1 className="text-2xl font-bold">
+                      {t("recover.title")}
+                    </h1>
+                  </div>
+                  {!otpSent && !success && (
+                    <form onSubmit={sendCode} className="flex flex-col gap-4">
+                      <Input
+                        type="email"
+                        placeholder={t("login.email-placeholder")}
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                      />
+                      <Button type="submit">{t("recover.sendCode")}</Button>
+                    </form>
+                  )}
+                  {otpSent && !success && (
+                    <form
+                      onSubmit={resetPassword}
+                      className="flex flex-col gap-4"
+                    >
+                      <InputOTP
+                        maxLength={6}
+                        value={otp}
+                        onChange={(value) => setOtp(value)}
+                      >
+                        <InputOTPGroup>
+                          <InputOTPSlot index={0} />
+                          <InputOTPSlot index={1} />
+                          <InputOTPSlot index={2} />
+                          <InputOTPSeparator />
+                          <InputOTPSlot index={3} />
+                          <InputOTPSlot index={4} />
+                          <InputOTPSlot index={5} />
+                        </InputOTPGroup>
+                      </InputOTP>
+                      <Input
+                        type="password"
+                        placeholder={t("recover.newPassword")}
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                      />
+                      <Input
+                        type="password"
+                        placeholder={t("recover.confirmPassword")}
+                        value={passwordAgain}
+                        onChange={(e) => setPasswordAgain(e.target.value)}
+                      />
+                      <Button type="submit">{t("recover.submit")}</Button>
+                    </form>
+                  )}
+                  {success && (
+                    <div className="text-center text-sm">
+                      <p>{t("recover.success")}</p>
+                      <Link
+                        to="/login"
+                        className="underline underline-offset-4"
+                      >
+                        {t("recover.backToLogin")}
+                      </Link>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div className="relative hidden bg-background md:flex md:items-center md:justify-center">
+                <img
+                  src="/assets/mascot/mascot_worried_face.png"
+                  alt={t("recover.title")}
+                  className="w-60 object-contain"
+                />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default RecoverPage;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -36,8 +36,19 @@
     "password-placeholder": "Write here...",
     "privacyPolicy": "Privacy Policy",
     "signUp": "Sign up",
+    "forgotPassword": "Forgot your password?",
+    "recoverPassword": "Recover",
     "termsOfService": "Terms of Service",
     "welcomeBack": "Welcome back"
+  },
+  "recover": {
+    "title": "Recover password",
+    "sendCode": "Send code",
+    "newPassword": "New password",
+    "confirmPassword": "Confirm password",
+    "submit": "Reset password",
+    "success": "Password reset successfully",
+    "backToLogin": "Back to login"
   },
   "register": {
     "agreeTo": "By clicking sign up, you agree to our",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -43,12 +43,14 @@
   },
   "recover": {
     "title": "Recover password",
-    "sendEmail": "Send reset link",
+    "sendCode": "Send code",
+    "code": "Code",
     "newPassword": "New password",
     "confirmPassword": "Confirm password",
     "submit": "Reset password",
-    "emailSent": "Check your email for the password reset link",
+    "emailSent": "Check your email for the verification code",
     "success": "Password reset successfully",
+    "passwordMismatch": "Passwords do not match",
     "backToLogin": "Back to login"
   },
   "register": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -43,10 +43,11 @@
   },
   "recover": {
     "title": "Recover password",
-    "sendCode": "Send code",
+    "sendEmail": "Send reset link",
     "newPassword": "New password",
     "confirmPassword": "Confirm password",
     "submit": "Reset password",
+    "emailSent": "Check your email for the password reset link",
     "success": "Password reset successfully",
     "backToLogin": "Back to login"
   },

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -42,12 +42,14 @@
   },
   "recover": {
     "title": "Recuperar senha",
-    "sendEmail": "Enviar link",
+    "sendCode": "Enviar código",
+    "code": "Código",
     "newPassword": "Nova senha",
     "confirmPassword": "Confirmar senha",
     "submit": "Redefinir senha",
-    "emailSent": "Verifique seu email pelo link de recuperação",
+    "emailSent": "Verifique seu email pelo código de recuperação",
     "success": "Senha redefinida com sucesso",
+    "passwordMismatch": "As senhas não coincidem",
     "backToLogin": "Voltar para login"
   },
   "register": {

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -35,8 +35,19 @@
     "password-placeholder": "Digite aqui...",
     "privacyPolicy": "Política de Privacidade",
     "signUp": "Cadastre-se",
+    "forgotPassword": "Esqueceu sua senha?",
+    "recoverPassword": "Recuperar",
     "termsOfService": "Termos de Serviço",
     "welcomeBack": "Bem-vindo de volta"
+  },
+  "recover": {
+    "title": "Recuperar senha",
+    "sendCode": "Enviar código",
+    "newPassword": "Nova senha",
+    "confirmPassword": "Confirmar senha",
+    "submit": "Redefinir senha",
+    "success": "Senha redefinida com sucesso",
+    "backToLogin": "Voltar para login"
   },
   "register": {
     "agreeTo": "Ao clicar em cadastrar, você concorda com nossos",

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -42,10 +42,11 @@
   },
   "recover": {
     "title": "Recuperar senha",
-    "sendCode": "Enviar código",
+    "sendEmail": "Enviar link",
     "newPassword": "Nova senha",
     "confirmPassword": "Confirmar senha",
     "submit": "Redefinir senha",
+    "emailSent": "Verifique seu email pelo link de recuperação",
     "success": "Senha redefinida com sucesso",
     "backToLogin": "Voltar para login"
   },


### PR DESCRIPTION
## Summary
- add recovery page using Appwrite email OTP
- create OTP input component and translations
- link recovery flow from login page

## Testing
- `pnpm run build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a11a84b7dc832ebba6d53a4ed51b66