### PR TITLE
feat: add account settings page

### DIFF
--- a/src/components/settings/password-credenza.tsx
+++ b/src/components/settings/password-credenza.tsx
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import {
+  Credenza,
+  CredenzaContent,
+  CredenzaHeader,
+  CredenzaTitle,
+  CredenzaBody,
+  CredenzaFooter,
+  CredenzaClose,
+} from "@/components/ui/credenza";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useTranslate } from "@tolgee/react";
+
+const passwordSchema = z.object({ password: z.string().min(1) });
+
+export function PasswordCredenza({
+  open,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (password: string) => void;
+}) {
+  const { t } = useTranslate();
+  const form = useForm<{ password: string }>({
+    resolver: zodResolver(passwordSchema),
+    defaultValues: { password: "" },
+  });
+
+  return (
+    <Credenza open={open} onOpenChange={(o) => { onOpenChange(o); if (!o) form.reset(); }}>
+      <CredenzaContent>
+        <CredenzaHeader>
+          <CredenzaTitle>{t("settings.passwordCredenza.title")}</CredenzaTitle>
+        </CredenzaHeader>
+        <CredenzaBody>
+          <Form {...form}>
+            <form
+              id="password-form"
+              onSubmit={form.handleSubmit(({ password }) => {
+                onConfirm(password);
+                form.reset();
+              })}
+              className="space-y-4"
+            >
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("settings.passwordCredenza.password")}</FormLabel>
+                    <FormControl>
+                      <Input type="password" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </form>
+          </Form>
+        </CredenzaBody>
+        <CredenzaFooter>
+          <CredenzaClose asChild>
+            <Button type="button" variant="outline">
+              {t("settings.passwordCredenza.cancel")}
+            </Button>
+          </CredenzaClose>
+          <Button type="submit" form="password-form">
+            {t("settings.passwordCredenza.confirm")}
+          </Button>
+        </CredenzaFooter>
+      </CredenzaContent>
+    </Credenza>
+  );
+}

--- a/src/components/settings/sessions-list.tsx
+++ b/src/components/settings/sessions-list.tsx
@@ -1,0 +1,63 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { account } from "@/lib/appwrite";
+import { toast } from "sonner";
+import { useTranslate } from "@tolgee/react";
+
+export function SessionsList({ className }: { className?: string }) {
+  const { t } = useTranslate();
+  const { data: sessionsData, refetch } = useQuery({
+    queryKey: ["sessions"],
+    queryFn: async () => (await account.listSessions()).sessions,
+  });
+  const deleteSessionMutation = useMutation({
+    mutationFn: (id: string) => account.deleteSession(id),
+    onSuccess: () => {
+      toast.success(t("settings.sessions.sessionRemoved"));
+      refetch();
+    },
+    onError: (err: any) => toast.error(err.message),
+  });
+  const deleteAllSessionsMutation = useMutation({
+    mutationFn: () => account.deleteSessions(),
+    onSuccess: () => {
+      toast.success(t("settings.sessions.allSessionsRemoved"));
+      refetch();
+    },
+    onError: (err: any) => toast.error(err.message),
+  });
+
+  return (
+    <div className={`space-y-4 rounded-lg border p-4 ${className ?? ""}`}>
+      <h2 className="text-lg font-semibold">{t("settings.sessions.title")}</h2>
+      <div className="space-y-2">
+        {sessionsData?.map((s) => (
+          <div key={s.$id} className="flex items-center justify-between border-b pb-2">
+            <div>
+              <p className="text-sm">{s.clientName} - {s.osName}</p>
+              <p className="text-xs text-muted-foreground">{new Date(s.expire).toLocaleString()}</p>
+            </div>
+            {!s.current && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => deleteSessionMutation.mutate(s.$id)}
+              >
+                {t("settings.sessions.revoke")}
+              </Button>
+            )}
+          </div>
+        ))}
+        {sessionsData && sessionsData.length > 0 && (
+          <Button
+            variant="destructive"
+            loading={deleteAllSessionsMutation.status === "pending"}
+            onClick={() => deleteAllSessionsMutation.mutate()}
+          >
+            {t("settings.sessions.revokeAll")}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/update-email-form.tsx
+++ b/src/components/settings/update-email-form.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { account } from "@/lib/appwrite";
+import useSession from "@/hooks/queries/user";
+import { toast } from "sonner";
+import { PasswordCredenza } from "./password-credenza";
+import { useTranslate } from "@tolgee/react";
+
+export function UpdateEmailForm() {
+  const queryClient = useQueryClient();
+  const { data: session } = useSession();
+  const { t } = useTranslate();
+  const schema = z.object({ email: z.string().email() });
+  const form = useForm<{ email: string }>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: session?.email ?? "" },
+  });
+  useEffect(() => {
+    form.reset({ email: session?.email ?? "" });
+  }, [session]);
+
+  const mutation = useMutation({
+    mutationFn: ({ email, password }: { email: string; password: string }) =>
+      account.updateEmail(email, password),
+    onSuccess: (_, values) => {
+      queryClient.setQueryData(["session"], (old: any) => ({ ...old, email: values.email }));
+      toast.success(t("settings.updateEmail.success"));
+    },
+    onError: (err: any) => toast.error(err.message),
+  });
+
+  const [passwordOpen, setPasswordOpen] = useState(false);
+  const [pendingEmail, setPendingEmail] = useState<string>();
+
+  function handleSubmit(values: { email: string }) {
+    setPendingEmail(values.email);
+    setPasswordOpen(true);
+  }
+
+  function confirmPassword(password: string) {
+    if (pendingEmail) {
+      mutation.mutate({ email: pendingEmail, password });
+    }
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border p-4">
+      <h2 className="text-lg font-semibold">{t("settings.updateEmail.title")}</h2>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t("settings.updateEmail.email")}</FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    disabled={mutation.status === "pending"}
+                    onBlur={() => {
+                      field.onBlur();
+                      form.handleSubmit(handleSubmit)();
+                    }}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </form>
+      </Form>
+      <PasswordCredenza
+        open={passwordOpen}
+        onOpenChange={setPasswordOpen}
+        onConfirm={(password) => {
+          setPasswordOpen(false);
+          confirmPassword(password);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/settings/update-name-form.tsx
+++ b/src/components/settings/update-name-form.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { account } from "@/lib/appwrite";
+import useSession from "@/hooks/queries/user";
+import { toast } from "sonner";
+import { useTranslate } from "@tolgee/react";
+
+export function UpdateNameForm() {
+  const queryClient = useQueryClient();
+  const { data: session } = useSession();
+  const { t } = useTranslate();
+  const schema = z.object({ name: z.string().min(1) });
+  const form = useForm<{ name: string }>({
+    resolver: zodResolver(schema),
+    defaultValues: { name: session?.name ?? "" },
+  });
+  useEffect(() => {
+    form.reset({ name: session?.name ?? "" });
+  }, [session]);
+
+  const mutation = useMutation({
+    mutationFn: ({ name }: { name: string }) => account.updateName(name),
+    onSuccess: (_, values) => {
+      queryClient.setQueryData(["session"], (old: any) => ({ ...old, name: values.name }));
+      toast.success(t("settings.updateName.success"));
+    },
+    onError: (err: any) => toast.error(err.message),
+  });
+
+  function handleSubmit(values: { name: string }) {
+    mutation.mutate(values);
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border p-4">
+      <h2 className="text-lg font-semibold">{t("settings.updateName.title")}</h2>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t("settings.updateName.name")}</FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    disabled={mutation.status === "pending"}
+                    onBlur={() => {
+                      field.onBlur();
+                      form.handleSubmit(handleSubmit)();
+                    }}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/src/components/settings/update-phone-form.tsx
+++ b/src/components/settings/update-phone-form.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { account } from "@/lib/appwrite";
+import useSession from "@/hooks/queries/user";
+import { toast } from "sonner";
+import { PasswordCredenza } from "./password-credenza";
+import { useTranslate } from "@tolgee/react";
+
+export function UpdatePhoneForm() {
+  const queryClient = useQueryClient();
+  const { data: session } = useSession();
+  const { t } = useTranslate();
+  const schema = z.object({ phone: z.string().min(1) });
+  const form = useForm<{ phone: string }>({
+    resolver: zodResolver(schema),
+    defaultValues: { phone: session?.phone ?? "" },
+  });
+  useEffect(() => {
+    form.reset({ phone: session?.phone ?? "" });
+  }, [session]);
+
+  const mutation = useMutation({
+    mutationFn: ({ phone, password }: { phone: string; password: string }) =>
+      account.updatePhone(phone, password),
+    onSuccess: () => {
+      toast.success(t("settings.updatePhone.success"));
+      form.reset({ phone: "" });
+      queryClient.invalidateQueries({ queryKey: ["session"] });
+    },
+    onError: (err: any) => toast.error(err.message),
+  });
+
+  const [passwordOpen, setPasswordOpen] = useState(false);
+  const [pendingPhone, setPendingPhone] = useState<string>();
+
+  function handleSubmit(values: { phone: string }) {
+    setPendingPhone(values.phone);
+    setPasswordOpen(true);
+  }
+
+  function confirmPassword(password: string) {
+    if (pendingPhone) {
+      mutation.mutate({ phone: pendingPhone, password });
+    }
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border p-4">
+      <h2 className="text-lg font-semibold">{t("settings.updatePhone.title")}</h2>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="phone"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t("settings.updatePhone.phone")}</FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    disabled={mutation.status === "pending"}
+                    onBlur={() => {
+                      field.onBlur();
+                      form.handleSubmit(handleSubmit)();
+                    }}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </form>
+      </Form>
+      <PasswordCredenza
+        open={passwordOpen}
+        onOpenChange={setPasswordOpen}
+        onConfirm={(password) => {
+          setPasswordOpen(false);
+          confirmPassword(password);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/settings/update-preferences-form.tsx
+++ b/src/components/settings/update-preferences-form.tsx
@@ -1,0 +1,103 @@
+import { useEffect } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { account } from "@/lib/appwrite";
+import useSession from "@/hooks/queries/user";
+import { toast } from "sonner";
+import { useTolgee, useTranslate } from "@tolgee/react";
+
+export function UpdatePreferencesForm({ className }: { className?: string }) {
+  const queryClient = useQueryClient();
+  const { data: session } = useSession();
+  const tolgee = useTolgee(["language"]);
+  const { t } = useTranslate();
+  const schema = z.object({
+    language: z.string().min(1),
+    newsletter: z.boolean().optional(),
+  });
+  const form = useForm<{ language: string; newsletter?: boolean }>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      language: (session?.prefs as any)?.language ?? tolgee.getLanguage(),
+      newsletter: (session?.prefs as any)?.newsletter ?? false,
+    },
+  });
+  useEffect(() => {
+    form.reset({
+      language: (session?.prefs as any)?.language ?? tolgee.getLanguage(),
+      newsletter: (session?.prefs as any)?.newsletter ?? false,
+    });
+  }, [session, tolgee]);
+
+  const mutation = useMutation({
+    mutationFn: ({ language, newsletter }: { language: string; newsletter?: boolean }) =>
+      account.updatePrefs({ language, newsletter }),
+    onSuccess: (_, values) => {
+      tolgee.changeLanguage(values.language);
+      queryClient.setQueryData(["session"], (old: any) => ({
+        ...old,
+        prefs: { ...(old?.prefs ?? {}), language: values.language, newsletter: values.newsletter },
+      }));
+      toast.success(t("settings.preferences.success"));
+    },
+    onError: (err: any) => toast.error(err.message),
+  });
+
+  return (
+    <div className={`space-y-4 rounded-lg border p-4 ${className ?? ""}`}>
+      <h2 className="text-lg font-semibold">{t("settings.preferences.title")}</h2>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit((v) => mutation.mutate(v))} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="language"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t("settings.preferences.language")}</FormLabel>
+                <FormControl>
+                  <select
+                    {...field}
+                    className="w-full rounded border px-2 py-1"
+                    disabled={mutation.status === "pending"}
+                    onBlur={() => {
+                      field.onBlur();
+                      form.handleSubmit((v) => mutation.mutate(v))();
+                    }}
+                  >
+                    <option value="en">{t("settings.preferences.english")}</option>
+                    <option value="pt-BR">{t("settings.preferences.portuguese")}</option>
+                  </select>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="newsletter"
+            render={({ field }) => (
+              <FormItem className="flex items-center gap-2">
+                <FormControl>
+                  <input
+                    type="checkbox"
+                    checked={field.value}
+                    onChange={(e) => field.onChange(e.target.checked)}
+                    disabled={mutation.status === "pending"}
+                    onBlur={() => {
+                      field.onBlur();
+                      form.handleSubmit((v) => mutation.mutate(v))();
+                    }}
+                  />
+                </FormControl>
+                <FormLabel className="!mt-0">{t("settings.preferences.newsletter")}</FormLabel>
+              </FormItem>
+            )}
+          />
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -5,6 +5,7 @@ import {
   LifeBuoy,
   Send,
   Bot,
+  Settings,
   type LucideIcon,
 } from "lucide-react";
 
@@ -23,61 +24,68 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
-
-const data = {
-  user: {
-    name: "shadcn",
-    email: "m@example.com",
-    avatar: "/avatars/shadcn.jpg",
-  },
-  navMain: [
-    {
-      title: "Chat",
-      url: "/chat",
-      icon: Bot,
-    },
-    {
-      title: "Calendário",
-      url: "/home",
-      icon: Calendar,
-      items: [
-        {
-          title: "Início",
-          url: "/home",
-        },
-      ],
-    },
-  ],
-  navSecondary: [
-    {
-      title: "Support",
-      icon: LifeBuoy,
-      render: (item: { title: string; icon: LucideIcon }) => (
-        <ContactCredenza>
-          <SidebarMenuButton size="sm">
-            <item.icon />
-            <span>{item.title}</span>
-          </SidebarMenuButton>
-        </ContactCredenza>
-      ),
-    },
-    {
-      title: "Feedback",
-      icon: Send,
-      render: (item: { title: string; icon: LucideIcon }) => (
-        <FeedbackCredenza>
-          <SidebarMenuButton size="sm">
-            <item.icon />
-            <span>{item.title}</span>
-          </SidebarMenuButton>
-        </FeedbackCredenza>
-      ),
-    },
-  ],
-  projects: [],
-};
+import { useTranslate } from "@tolgee/react";
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  const { t } = useTranslate();
+  const data = {
+    user: {
+      name: "shadcn",
+      email: "m@example.com",
+      avatar: "/avatars/shadcn.jpg",
+    },
+    navMain: [
+      {
+        title: "Chat",
+        url: "/chat",
+        icon: Bot,
+      },
+      {
+        title: "Calendário",
+        url: "/home",
+        icon: Calendar,
+        items: [
+          {
+            title: "Início",
+            url: "/home",
+          },
+        ],
+      },
+      {
+        title: t("settings.title"),
+        url: "/settings",
+        icon: Settings,
+      },
+    ],
+    navSecondary: [
+      {
+        title: "Support",
+        icon: LifeBuoy,
+        render: (item: { title: string; icon: LucideIcon }) => (
+          <ContactCredenza>
+            <SidebarMenuButton size="sm">
+              <item.icon />
+              <span>{item.title}</span>
+            </SidebarMenuButton>
+          </ContactCredenza>
+        ),
+      },
+      {
+        title: "Feedback",
+        icon: Send,
+        render: (item: { title: string; icon: LucideIcon }) => (
+          <FeedbackCredenza>
+            <SidebarMenuButton size="sm">
+              <item.icon />
+              <span>{item.title}</span>
+            </SidebarMenuButton>
+          </FeedbackCredenza>
+        ),
+      },
+    ],
+    projects: [],
+  };
+
   return (
     <Sidebar variant="inset" {...props}>
       <SidebarHeader>

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as _authenticationLayoutRegisterRouteImport } from './routes/__au
 import { Route as _authenticationLayoutLoginRouteImport } from './routes/__authenticationLayout/login'
 import { Route as _authenticatedLayoutHomeRouteImport } from './routes/__authenticatedLayout/home'
 import { Route as _authenticatedLayoutChatRouteImport } from './routes/__authenticatedLayout/chat'
+import { Route as _authenticatedLayoutSettingsIndexRouteImport } from './routes/__authenticatedLayout/settings/index'
 
 const WaitlistDrawerTestRoute = WaitlistDrawerTestRouteImport.update({
   id: '/waitlist-drawer-test',
@@ -79,6 +80,12 @@ const _authenticatedLayoutChatRoute =
     path: '/chat',
     getParentRoute: () => _authenticatedLayoutRoute,
   } as any)
+const _authenticatedLayoutSettingsIndexRoute =
+  _authenticatedLayoutSettingsIndexRouteImport.update({
+    id: '/settings/',
+    path: '/settings/',
+    getParentRoute: () => _authenticatedLayoutRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/contact': typeof ContactRoute
@@ -90,6 +97,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof _authenticationLayoutLoginRoute
   '/register': typeof _authenticationLayoutRegisterRoute
   '/': typeof _authenticatedLayoutIndexRoute
+  '/settings': typeof _authenticatedLayoutSettingsIndexRoute
 }
 export interface FileRoutesByTo {
   '/contact': typeof ContactRoute
@@ -101,6 +109,7 @@ export interface FileRoutesByTo {
   '/login': typeof _authenticationLayoutLoginRoute
   '/register': typeof _authenticationLayoutRegisterRoute
   '/': typeof _authenticatedLayoutIndexRoute
+  '/settings': typeof _authenticatedLayoutSettingsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -115,6 +124,7 @@ export interface FileRoutesById {
   '/__authenticationLayout/login': typeof _authenticationLayoutLoginRoute
   '/__authenticationLayout/register': typeof _authenticationLayoutRegisterRoute
   '/__authenticatedLayout/': typeof _authenticatedLayoutIndexRoute
+  '/__authenticatedLayout/settings/': typeof _authenticatedLayoutSettingsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -128,6 +138,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/register'
     | '/'
+    | '/settings'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/contact'
@@ -139,6 +150,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/register'
     | '/'
+    | '/settings'
   id:
     | '__root__'
     | '/__authenticatedLayout'
@@ -152,6 +164,7 @@ export interface FileRouteTypes {
     | '/__authenticationLayout/login'
     | '/__authenticationLayout/register'
     | '/__authenticatedLayout/'
+    | '/__authenticatedLayout/settings/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -242,6 +255,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof _authenticatedLayoutChatRouteImport
       parentRoute: typeof _authenticatedLayoutRoute
     }
+    '/__authenticatedLayout/settings/': {
+      id: '/__authenticatedLayout/settings/'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof _authenticatedLayoutSettingsIndexRouteImport
+      parentRoute: typeof _authenticatedLayoutRoute
+    }
   }
 }
 
@@ -249,12 +269,15 @@ interface _authenticatedLayoutRouteChildren {
   _authenticatedLayoutChatRoute: typeof _authenticatedLayoutChatRoute
   _authenticatedLayoutHomeRoute: typeof _authenticatedLayoutHomeRoute
   _authenticatedLayoutIndexRoute: typeof _authenticatedLayoutIndexRoute
+  _authenticatedLayoutSettingsIndexRoute: typeof _authenticatedLayoutSettingsIndexRoute
 }
 
 const _authenticatedLayoutRouteChildren: _authenticatedLayoutRouteChildren = {
   _authenticatedLayoutChatRoute: _authenticatedLayoutChatRoute,
   _authenticatedLayoutHomeRoute: _authenticatedLayoutHomeRoute,
   _authenticatedLayoutIndexRoute: _authenticatedLayoutIndexRoute,
+  _authenticatedLayoutSettingsIndexRoute:
+    _authenticatedLayoutSettingsIndexRoute,
 }
 
 const _authenticatedLayoutRouteWithChildren =

--- a/src/routes/__authenticatedLayout/settings/index.tsx
+++ b/src/routes/__authenticatedLayout/settings/index.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { UpdateNameForm } from "@/components/settings/update-name-form";
+import { UpdateEmailForm } from "@/components/settings/update-email-form";
+import { UpdatePhoneForm } from "@/components/settings/update-phone-form";
+import { UpdatePreferencesForm } from "@/components/settings/update-preferences-form";
+import { SessionsList } from "@/components/settings/sessions-list";
+
+export const Route = createFileRoute("/__authenticatedLayout/settings/")({
+  component: SettingsPage,
+});
+
+function SettingsPage() {
+  return (
+    <div className="grid gap-6 md:grid-cols-2">
+      <UpdateNameForm />
+      <UpdateEmailForm />
+      <UpdatePhoneForm />
+      <UpdatePreferencesForm className="md:col-span-2" />
+      <SessionsList className="md:col-span-2" />
+    </div>
+  );
+}
+
+export default SettingsPage;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -91,5 +91,44 @@
     "invalidEmail": "Invalid email",
     "passwordMin": "Minimum {{count}} characters",
     "required": "Required field"
+  },
+  "settings": {
+    "title": "Settings",
+    "passwordCredenza": {
+      "title": "Confirm Update",
+      "password": "Password",
+      "cancel": "Cancel",
+      "confirm": "Confirm"
+    },
+    "sessions": {
+      "title": "Sessions",
+      "sessionRemoved": "Session removed",
+      "allSessionsRemoved": "All sessions removed",
+      "revoke": "Revoke",
+      "revokeAll": "Revoke All Sessions"
+    },
+    "updateEmail": {
+      "title": "Update Email",
+      "email": "Email",
+      "success": "Email updated"
+    },
+    "updateName": {
+      "title": "Update Name",
+      "name": "Name",
+      "success": "Name updated"
+    },
+    "updatePhone": {
+      "title": "Update Phone",
+      "phone": "Phone",
+      "success": "Phone updated"
+    },
+    "preferences": {
+      "title": "Preferences",
+      "success": "Preferences updated",
+      "language": "Language",
+      "english": "English",
+      "portuguese": "Português (Brasil)",
+      "newsletter": "Newsletter"
+    }
   }
 }

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -90,5 +90,44 @@
     "invalidEmail": "Email inválido",
     "passwordMin": "Mínimo de {{count}} caracteres",
     "required": "Campo obrigatório"
+  },
+  "settings": {
+    "title": "Configurações",
+    "passwordCredenza": {
+      "title": "Confirmar atualização",
+      "password": "Senha",
+      "cancel": "Cancelar",
+      "confirm": "Confirmar"
+    },
+    "sessions": {
+      "title": "Sessões",
+      "sessionRemoved": "Sessão removida",
+      "allSessionsRemoved": "Todas as sessões removidas",
+      "revoke": "Revogar",
+      "revokeAll": "Revogar todas as sessões"
+    },
+    "updateEmail": {
+      "title": "Atualizar email",
+      "email": "Email",
+      "success": "Email atualizado"
+    },
+    "updateName": {
+      "title": "Atualizar nome",
+      "name": "Nome",
+      "success": "Nome atualizado"
+    },
+    "updatePhone": {
+      "title": "Atualizar telefone",
+      "phone": "Telefone",
+      "success": "Telefone atualizado"
+    },
+    "preferences": {
+      "title": "Preferências",
+      "success": "Preferências atualizadas",
+      "language": "Idioma",
+      "english": "Inglês",
+      "portuguese": "Português (Brasil)",
+      "newsletter": "Newsletter"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- auto-submit account settings fields on blur or Enter, removing inline save buttons
- eliminate custom InputWithButton component and unused save translations
- prevent users from revoking their current session

## Testing
- `pnpm test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a11b3d3a6c832ea3f3a178e661f81f