### PR TITLE
feat: add password recovery flow

### DIFF
--- a/src/components/login/email-and-password.tsx
+++ b/src/components/login/email-and-password.tsx
@@ -12,7 +12,7 @@ import { Input } from "@/components/ui/input";
 import { account } from "@/lib/appwrite";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
-import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useNavigate, useSearch, Link } from "@tanstack/react-router";
 import { useTranslate } from "@tolgee/react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -108,6 +108,15 @@ const EmailAndPasswordForm = () => {
               </FormItem>
             )}
           />
+        </div>
+        <div className="text-right text-sm">
+          <Link
+            to="/recover"
+            search={{ userId: undefined, secret: undefined }}
+            className="underline underline-offset-4"
+          >
+            {t("login.forgotPassword")}
+          </Link>
         </div>
         <Button
           loading={isPending ? `${t("feedback.loading")}...` : undefined}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,8 @@ import { Route as _authenticationLayoutRouteImport } from './routes/__authentica
 import { Route as _authenticatedLayoutRouteImport } from './routes/__authenticatedLayout'
 import { Route as _authenticatedLayoutIndexRouteImport } from './routes/__authenticatedLayout/index'
 import { Route as _authenticationLayoutRegisterRouteImport } from './routes/__authenticationLayout/register'
+import { Route as _authenticationLayoutRecoverRouteImport } from './routes/__authenticationLayout/recover'
+import { Route as _authenticationLayoutPasswordChangedRouteImport } from './routes/__authenticationLayout/password-changed'
 import { Route as _authenticationLayoutLoginRouteImport } from './routes/__authenticationLayout/login'
 import { Route as _authenticatedLayoutHomeRouteImport } from './routes/__authenticatedLayout/home'
 import { Route as _authenticatedLayoutChatRouteImport } from './routes/__authenticatedLayout/chat'
@@ -61,6 +63,18 @@ const _authenticationLayoutRegisterRoute =
     path: '/register',
     getParentRoute: () => _authenticationLayoutRoute,
   } as any)
+const _authenticationLayoutRecoverRoute =
+  _authenticationLayoutRecoverRouteImport.update({
+    id: '/recover',
+    path: '/recover',
+    getParentRoute: () => _authenticationLayoutRoute,
+  } as any)
+const _authenticationLayoutPasswordChangedRoute =
+  _authenticationLayoutPasswordChangedRouteImport.update({
+    id: '/password-changed',
+    path: '/password-changed',
+    getParentRoute: () => _authenticationLayoutRoute,
+  } as any)
 const _authenticationLayoutLoginRoute =
   _authenticationLayoutLoginRouteImport.update({
     id: '/login',
@@ -88,6 +102,8 @@ export interface FileRoutesByFullPath {
   '/chat': typeof _authenticatedLayoutChatRoute
   '/home': typeof _authenticatedLayoutHomeRoute
   '/login': typeof _authenticationLayoutLoginRoute
+  '/password-changed': typeof _authenticationLayoutPasswordChangedRoute
+  '/recover': typeof _authenticationLayoutRecoverRoute
   '/register': typeof _authenticationLayoutRegisterRoute
   '/': typeof _authenticatedLayoutIndexRoute
 }
@@ -99,6 +115,8 @@ export interface FileRoutesByTo {
   '/chat': typeof _authenticatedLayoutChatRoute
   '/home': typeof _authenticatedLayoutHomeRoute
   '/login': typeof _authenticationLayoutLoginRoute
+  '/password-changed': typeof _authenticationLayoutPasswordChangedRoute
+  '/recover': typeof _authenticationLayoutRecoverRoute
   '/register': typeof _authenticationLayoutRegisterRoute
   '/': typeof _authenticatedLayoutIndexRoute
 }
@@ -113,6 +131,8 @@ export interface FileRoutesById {
   '/__authenticatedLayout/chat': typeof _authenticatedLayoutChatRoute
   '/__authenticatedLayout/home': typeof _authenticatedLayoutHomeRoute
   '/__authenticationLayout/login': typeof _authenticationLayoutLoginRoute
+  '/__authenticationLayout/password-changed': typeof _authenticationLayoutPasswordChangedRoute
+  '/__authenticationLayout/recover': typeof _authenticationLayoutRecoverRoute
   '/__authenticationLayout/register': typeof _authenticationLayoutRegisterRoute
   '/__authenticatedLayout/': typeof _authenticatedLayoutIndexRoute
 }
@@ -126,6 +146,8 @@ export interface FileRouteTypes {
     | '/chat'
     | '/home'
     | '/login'
+    | '/password-changed'
+    | '/recover'
     | '/register'
     | '/'
   fileRoutesByTo: FileRoutesByTo
@@ -137,6 +159,8 @@ export interface FileRouteTypes {
     | '/chat'
     | '/home'
     | '/login'
+    | '/password-changed'
+    | '/recover'
     | '/register'
     | '/'
   id:
@@ -150,6 +174,8 @@ export interface FileRouteTypes {
     | '/__authenticatedLayout/chat'
     | '/__authenticatedLayout/home'
     | '/__authenticationLayout/login'
+    | '/__authenticationLayout/password-changed'
+    | '/__authenticationLayout/recover'
     | '/__authenticationLayout/register'
     | '/__authenticatedLayout/'
   fileRoutesById: FileRoutesById
@@ -221,6 +247,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof _authenticationLayoutRegisterRouteImport
       parentRoute: typeof _authenticationLayoutRoute
     }
+    '/__authenticationLayout/recover': {
+      id: '/__authenticationLayout/recover'
+      path: '/recover'
+      fullPath: '/recover'
+      preLoaderRoute: typeof _authenticationLayoutRecoverRouteImport
+      parentRoute: typeof _authenticationLayoutRoute
+    }
+    '/__authenticationLayout/password-changed': {
+      id: '/__authenticationLayout/password-changed'
+      path: '/password-changed'
+      fullPath: '/password-changed'
+      preLoaderRoute: typeof _authenticationLayoutPasswordChangedRouteImport
+      parentRoute: typeof _authenticationLayoutRoute
+    }
     '/__authenticationLayout/login': {
       id: '/__authenticationLayout/login'
       path: '/login'
@@ -262,11 +302,16 @@ const _authenticatedLayoutRouteWithChildren =
 
 interface _authenticationLayoutRouteChildren {
   _authenticationLayoutLoginRoute: typeof _authenticationLayoutLoginRoute
+  _authenticationLayoutPasswordChangedRoute: typeof _authenticationLayoutPasswordChangedRoute
+  _authenticationLayoutRecoverRoute: typeof _authenticationLayoutRecoverRoute
   _authenticationLayoutRegisterRoute: typeof _authenticationLayoutRegisterRoute
 }
 
 const _authenticationLayoutRouteChildren: _authenticationLayoutRouteChildren = {
   _authenticationLayoutLoginRoute: _authenticationLayoutLoginRoute,
+  _authenticationLayoutPasswordChangedRoute:
+    _authenticationLayoutPasswordChangedRoute,
+  _authenticationLayoutRecoverRoute: _authenticationLayoutRecoverRoute,
   _authenticationLayoutRegisterRoute: _authenticationLayoutRegisterRoute,
 }
 

--- a/src/routes/__authenticationLayout/password-changed.tsx
+++ b/src/routes/__authenticationLayout/password-changed.tsx
@@ -1,0 +1,31 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useTranslate } from "@tolgee/react";
+
+export const Route = createFileRoute("/__authenticationLayout/password-changed")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { t } = useTranslate();
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-muted py-6 md:py-10">
+      <div className="w-full max-w-sm">
+        <Card>
+          <CardContent className="p-6 text-center space-y-4">
+            <h1 className="text-2xl font-bold">{t("recover.successTitle")}</h1>
+            <p className="text-muted-foreground">
+              {t("recover.successDescription")}
+            </p>
+            <Button asChild className="w-full">
+              <Link to="/login">{t("recover.backToLogin")}</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default RouteComponent;

--- a/src/routes/__authenticationLayout/recover.tsx
+++ b/src/routes/__authenticationLayout/recover.tsx
@@ -1,0 +1,230 @@
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { account } from "@/lib/appwrite";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useMutation } from "@tanstack/react-query";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { useTranslate } from "@tolgee/react";
+import { toast } from "sonner";
+import { z } from "zod";
+
+export const Route = createFileRoute("/__authenticationLayout/recover")({
+  component: RouteComponent,
+  validateSearch: (search: Record<string, unknown>) => ({
+    userId: search.userId as string | undefined,
+    secret: search.secret as string | undefined,
+  }),
+});
+
+function RouteComponent() {
+  const { userId, secret } = Route.useSearch();
+  return userId && secret ? (
+    <ResetPasswordForm userId={userId} secret={secret} />
+  ) : (
+    <RequestForm />
+  );
+}
+
+function PageLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-muted py-6 md:py-10">
+      <div className="w-full max-w-sm">
+        <div className="flex flex-col gap-6">
+          <Card>
+            <CardContent className="p-6">{children}</CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RequestForm() {
+  const { t } = useTranslate();
+
+  const formSchema = z.object({
+    email: z
+      .string()
+      .nonempty({ message: t("validation.required") })
+      .refine((val) => z.email().safeParse(val).success, {
+        message: t("validation.invalidEmail"),
+      }),
+  });
+
+  type FormValues = z.infer<typeof formSchema>;
+
+  const formMethods = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { email: "" },
+  });
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (data: FormValues) =>
+      account.createRecovery(data.email, `${window.location.origin}/recover`),
+    onSuccess: () => {
+      toast.success(t("recover.emailSent"));
+    },
+    onError: (err: any) => {
+      toast.error(err.message);
+    },
+  });
+
+  return (
+    <PageLayout>
+      <div className="flex flex-col gap-6">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">{t("recover.title")}</h1>
+        </div>
+        <Form {...formMethods}>
+          <form
+            className="grid gap-4"
+            onSubmit={formMethods.handleSubmit((values) => mutate(values))}
+          >
+            <FormField
+              control={formMethods.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("recover.email")}</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={t("recover.emailPlaceholder")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button
+              loading={isPending ? `${t("feedback.loading")}...` : undefined}
+              type="submit"
+              className="w-full"
+            >
+              {t("recover.send")}
+            </Button>
+          </form>
+        </Form>
+        <div className="text-center text-sm">
+          <Link to="/login" className="underline underline-offset-4">
+            {t("register.login")}
+          </Link>
+        </div>
+      </div>
+    </PageLayout>
+  );
+}
+
+function ResetPasswordForm({
+  userId,
+  secret,
+}: {
+  userId: string;
+  secret: string;
+}) {
+  const { t } = useTranslate();
+  const navigate = useNavigate({ from: "/recover" });
+
+  const formSchema = z
+    .object({
+      password: z
+        .string()
+        .nonempty({ message: t("validation.required") })
+        .min(8, { message: t("validation.passwordMin", { count: 8 }) }),
+      confirmPassword: z
+        .string()
+        .nonempty({ message: t("validation.required") }),
+    })
+    .refine((data) => data.password === data.confirmPassword, {
+      message: t("validation.passwordMismatch"),
+      path: ["confirmPassword"],
+    });
+
+  type FormValues = z.infer<typeof formSchema>;
+
+  const formMethods = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { password: "", confirmPassword: "" },
+  });
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (data: FormValues) =>
+      account.updateRecovery(userId, secret, data.password),
+    onSuccess: () => {
+      navigate({ to: "/password-changed" });
+    },
+    onError: (err: any) => {
+      toast.error(err.message);
+    },
+  });
+
+  return (
+    <PageLayout>
+      <div className="flex flex-col gap-6">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">{t("recover.title")}</h1>
+        </div>
+        <Form {...formMethods}>
+          <form
+            className="grid gap-4"
+            onSubmit={formMethods.handleSubmit((values) => mutate(values))}
+          >
+            <FormField
+              control={formMethods.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("recover.newPassword")}</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="password"
+                      placeholder={t("login.password-placeholder")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={formMethods.control}
+              name="confirmPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("recover.confirmPassword")}</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="password"
+                      placeholder={t("login.password-placeholder")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button
+              loading={isPending ? `${t("feedback.loading")}...` : undefined}
+              type="submit"
+              className="w-full"
+            >
+              {t("recover.submit")}
+            </Button>
+          </form>
+        </Form>
+      </div>
+    </PageLayout>
+  );
+}
+
+export default RouteComponent;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -37,7 +37,8 @@
     "privacyPolicy": "Privacy Policy",
     "signUp": "Sign up",
     "termsOfService": "Terms of Service",
-    "welcomeBack": "Welcome back"
+    "welcomeBack": "Welcome back",
+    "forgotPassword": "Forgot password?"
   },
   "register": {
     "agreeTo": "By clicking sign up, you agree to our",
@@ -56,6 +57,19 @@
     "signUpWithAppleOrGoogle": "Sign up with your account",
     "signUpWithGoogle": "Sign up with Google",
     "termsOfService": "Terms of Service"
+  },
+  "recover": {
+    "title": "Recover password",
+    "email": "Email",
+    "emailPlaceholder": "Write your email...",
+    "send": "Send recovery email",
+    "emailSent": "Check your email for the recovery link",
+    "newPassword": "New password",
+    "confirmPassword": "Confirm password",
+    "submit": "Change password",
+    "successTitle": "Password changed",
+    "successDescription": "You can now log in with your new password.",
+    "backToLogin": "Back to login"
   },
   "waitlist": {
     "title": "Join the waitlist",
@@ -90,6 +104,7 @@
   "validation": {
     "invalidEmail": "Invalid email",
     "passwordMin": "Minimum {{count}} characters",
-    "required": "Required field"
+    "required": "Required field",
+    "passwordMismatch": "Passwords do not match"
   }
 }

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -36,7 +36,8 @@
     "privacyPolicy": "Política de Privacidade",
     "signUp": "Cadastre-se",
     "termsOfService": "Termos de Serviço",
-    "welcomeBack": "Bem-vindo de volta"
+    "welcomeBack": "Bem-vindo de volta",
+    "forgotPassword": "Esqueceu a senha?"
   },
   "register": {
     "agreeTo": "Ao clicar em cadastrar, você concorda com nossos",
@@ -55,6 +56,19 @@
     "signUpWithAppleOrGoogle": "Cadastre-se com sua conta",
     "signUpWithGoogle": "Cadastre-se com Google",
     "termsOfService": "Termos de Serviço"
+  },
+  "recover": {
+    "title": "Recuperar senha",
+    "email": "Email",
+    "emailPlaceholder": "Digite seu email...",
+    "send": "Enviar link de recuperação",
+    "emailSent": "Confira seu email para o link de recuperação",
+    "newPassword": "Nova senha",
+    "confirmPassword": "Confirmar senha",
+    "submit": "Alterar senha",
+    "successTitle": "Senha alterada",
+    "successDescription": "Agora você pode entrar com sua nova senha.",
+    "backToLogin": "Voltar para o login"
   },
   "waitlist": {
     "title": "Entre na lista de espera",
@@ -89,6 +103,7 @@
   "validation": {
     "invalidEmail": "Email inválido",
     "passwordMin": "Mínimo de {{count}} caracteres",
-    "required": "Campo obrigatório"
+    "required": "Campo obrigatório",
+    "passwordMismatch": "As senhas não coincidem"
   }
 }


### PR DESCRIPTION
## Summary
- add password recovery page with email and reset forms
- show password reset success page
- link login screen to recovery flow and translate strings

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a12977a708832e907944d6670f8cc2