### PR TITLE
Add password recovery flow

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -20,6 +20,9 @@ import { Route as _authenticationLayoutRegisterRouteImport } from './routes/__au
 import { Route as _authenticationLayoutLoginRouteImport } from './routes/__authenticationLayout/login'
 import { Route as _authenticatedLayoutHomeRouteImport } from './routes/__authenticatedLayout/home'
 import { Route as _authenticatedLayoutChatRouteImport } from './routes/__authenticatedLayout/chat'
+import { Route as _authenticationLayoutRecoverIndexRouteImport } from './routes/__authenticationLayout/recover/index'
+import { Route as _authenticationLayoutRecoverSuccessRouteImport } from './routes/__authenticationLayout/recover/success'
+import { Route as _authenticationLayoutRecoverResetRouteImport } from './routes/__authenticationLayout/recover/reset'
 
 const WaitlistDrawerTestRoute = WaitlistDrawerTestRouteImport.update({
   id: '/waitlist-drawer-test',
@@ -79,6 +82,24 @@ const _authenticatedLayoutChatRoute =
     path: '/chat',
     getParentRoute: () => _authenticatedLayoutRoute,
   } as any)
+const _authenticationLayoutRecoverIndexRoute =
+  _authenticationLayoutRecoverIndexRouteImport.update({
+    id: '/recover/',
+    path: '/recover/',
+    getParentRoute: () => _authenticationLayoutRoute,
+  } as any)
+const _authenticationLayoutRecoverSuccessRoute =
+  _authenticationLayoutRecoverSuccessRouteImport.update({
+    id: '/recover/success',
+    path: '/recover/success',
+    getParentRoute: () => _authenticationLayoutRoute,
+  } as any)
+const _authenticationLayoutRecoverResetRoute =
+  _authenticationLayoutRecoverResetRouteImport.update({
+    id: '/recover/reset',
+    path: '/recover/reset',
+    getParentRoute: () => _authenticationLayoutRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/contact': typeof ContactRoute
@@ -90,6 +111,9 @@ export interface FileRoutesByFullPath {
   '/login': typeof _authenticationLayoutLoginRoute
   '/register': typeof _authenticationLayoutRegisterRoute
   '/': typeof _authenticatedLayoutIndexRoute
+  '/recover/reset': typeof _authenticationLayoutRecoverResetRoute
+  '/recover/success': typeof _authenticationLayoutRecoverSuccessRoute
+  '/recover': typeof _authenticationLayoutRecoverIndexRoute
 }
 export interface FileRoutesByTo {
   '/contact': typeof ContactRoute
@@ -101,6 +125,9 @@ export interface FileRoutesByTo {
   '/login': typeof _authenticationLayoutLoginRoute
   '/register': typeof _authenticationLayoutRegisterRoute
   '/': typeof _authenticatedLayoutIndexRoute
+  '/recover/reset': typeof _authenticationLayoutRecoverResetRoute
+  '/recover/success': typeof _authenticationLayoutRecoverSuccessRoute
+  '/recover': typeof _authenticationLayoutRecoverIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -115,6 +142,9 @@ export interface FileRoutesById {
   '/__authenticationLayout/login': typeof _authenticationLayoutLoginRoute
   '/__authenticationLayout/register': typeof _authenticationLayoutRegisterRoute
   '/__authenticatedLayout/': typeof _authenticatedLayoutIndexRoute
+  '/__authenticationLayout/recover/reset': typeof _authenticationLayoutRecoverResetRoute
+  '/__authenticationLayout/recover/success': typeof _authenticationLayoutRecoverSuccessRoute
+  '/__authenticationLayout/recover/': typeof _authenticationLayoutRecoverIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -128,6 +158,9 @@ export interface FileRouteTypes {
     | '/login'
     | '/register'
     | '/'
+    | '/recover/reset'
+    | '/recover/success'
+    | '/recover'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/contact'
@@ -139,6 +172,9 @@ export interface FileRouteTypes {
     | '/login'
     | '/register'
     | '/'
+    | '/recover/reset'
+    | '/recover/success'
+    | '/recover'
   id:
     | '__root__'
     | '/__authenticatedLayout'
@@ -152,6 +188,9 @@ export interface FileRouteTypes {
     | '/__authenticationLayout/login'
     | '/__authenticationLayout/register'
     | '/__authenticatedLayout/'
+    | '/__authenticationLayout/recover/reset'
+    | '/__authenticationLayout/recover/success'
+    | '/__authenticationLayout/recover/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -242,6 +281,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof _authenticatedLayoutChatRouteImport
       parentRoute: typeof _authenticatedLayoutRoute
     }
+    '/__authenticationLayout/recover/': {
+      id: '/__authenticationLayout/recover/'
+      path: '/recover'
+      fullPath: '/recover'
+      preLoaderRoute: typeof _authenticationLayoutRecoverIndexRouteImport
+      parentRoute: typeof _authenticationLayoutRoute
+    }
+    '/__authenticationLayout/recover/success': {
+      id: '/__authenticationLayout/recover/success'
+      path: '/recover/success'
+      fullPath: '/recover/success'
+      preLoaderRoute: typeof _authenticationLayoutRecoverSuccessRouteImport
+      parentRoute: typeof _authenticationLayoutRoute
+    }
+    '/__authenticationLayout/recover/reset': {
+      id: '/__authenticationLayout/recover/reset'
+      path: '/recover/reset'
+      fullPath: '/recover/reset'
+      preLoaderRoute: typeof _authenticationLayoutRecoverResetRouteImport
+      parentRoute: typeof _authenticationLayoutRoute
+    }
   }
 }
 
@@ -263,11 +323,20 @@ const _authenticatedLayoutRouteWithChildren =
 interface _authenticationLayoutRouteChildren {
   _authenticationLayoutLoginRoute: typeof _authenticationLayoutLoginRoute
   _authenticationLayoutRegisterRoute: typeof _authenticationLayoutRegisterRoute
+  _authenticationLayoutRecoverResetRoute: typeof _authenticationLayoutRecoverResetRoute
+  _authenticationLayoutRecoverSuccessRoute: typeof _authenticationLayoutRecoverSuccessRoute
+  _authenticationLayoutRecoverIndexRoute: typeof _authenticationLayoutRecoverIndexRoute
 }
 
 const _authenticationLayoutRouteChildren: _authenticationLayoutRouteChildren = {
   _authenticationLayoutLoginRoute: _authenticationLayoutLoginRoute,
   _authenticationLayoutRegisterRoute: _authenticationLayoutRegisterRoute,
+  _authenticationLayoutRecoverResetRoute:
+    _authenticationLayoutRecoverResetRoute,
+  _authenticationLayoutRecoverSuccessRoute:
+    _authenticationLayoutRecoverSuccessRoute,
+  _authenticationLayoutRecoverIndexRoute:
+    _authenticationLayoutRecoverIndexRoute,
 }
 
 const _authenticationLayoutRouteWithChildren =

--- a/src/routes/__authenticationLayout/login.tsx
+++ b/src/routes/__authenticationLayout/login.tsx
@@ -61,6 +61,15 @@ function RouteComponent() {
                   </div>
                   <EmailAndPasswordForm />
                   <div className="text-center text-sm">
+                    {t("login.forgotPassword")}{" "}
+                    <Link
+                      to="/recover"
+                      className="underline underline-offset-4"
+                    >
+                      {t("login.recover")}
+                    </Link>
+                  </div>
+                  <div className="text-center text-sm">
                     {t("login.dontHaveAccount")}{" "}
                     <Link
                       to="/register"

--- a/src/routes/__authenticationLayout/recover/index.tsx
+++ b/src/routes/__authenticationLayout/recover/index.tsx
@@ -1,0 +1,103 @@
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { account } from "@/lib/appwrite";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { useTranslate } from "@tolgee/react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { Card, CardContent } from "@/components/ui/card";
+
+export const Route = createFileRoute("/__authenticationLayout/recover/")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { t } = useTranslate();
+  const formSchema = z.object({
+    email: z
+      .string()
+      .nonempty({ message: t("validation.required") })
+      .refine((val) => z.email().safeParse(val).success, {
+        message: t("validation.invalidEmail"),
+      }),
+  });
+  type FormValues = z.infer<typeof formSchema>;
+  const formMethods = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { email: "" },
+  });
+  const { mutate, isPending } = useMutation({
+    mutationFn: (data: FormValues) =>
+      account.createRecovery(
+        data.email,
+        `${window.location.origin}/recover/reset`
+      ),
+    onSuccess: () => {
+      toast.success(t("recover.success"));
+    },
+    onError: (err: any) => {
+      toast.error(err.message);
+    },
+  });
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-muted py-6 md:py-10">
+      <div className="w-full max-w-sm">
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex flex-col gap-6">
+              <div className="flex flex-col items-center text-center">
+                <h1 className="text-2xl font-bold">{t("recover.title")}</h1>
+                <p className="text-balance text-muted-foreground">
+                  {t("recover.description")}
+                </p>
+              </div>
+              <Form {...formMethods}>
+                <form
+                  className="grid gap-6"
+                  onSubmit={formMethods.handleSubmit((values) => mutate(values))}
+                >
+                  <FormField
+                    control={formMethods.control}
+                    name="email"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("recover.email")}</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder={t("recover.emailPlaceholder")}
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <Button
+                    loading={
+                      isPending ? `${t("feedback.loading")}...` : undefined
+                    }
+                    type="submit"
+                    className="w-full"
+                  >
+                    {t("recover.submit")}
+                  </Button>
+                </form>
+              </Form>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/__authenticationLayout/recover/reset.tsx
+++ b/src/routes/__authenticationLayout/recover/reset.tsx
@@ -1,0 +1,136 @@
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { account } from "@/lib/appwrite";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
+import { useTranslate } from "@tolgee/react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface ResetSearch {
+  userId: string;
+  secret: string;
+}
+
+export const Route = createFileRoute("/__authenticationLayout/recover/reset")({
+  component: RouteComponent,
+  beforeLoad: ({ search }) => {
+    if (!search.userId || !search.secret)
+      throw redirect({ to: "/recover" });
+  },
+  validateSearch: (search: Record<string, unknown>): ResetSearch => {
+    return {
+      userId: search.userId as string,
+      secret: search.secret as string,
+    };
+  },
+});
+
+function RouteComponent() {
+  const { t } = useTranslate();
+  const navigate = useNavigate({ from: "/recover/reset" });
+  const { userId, secret } = Route.useSearch();
+
+  const formSchema = z
+    .object({
+      password: z
+        .string()
+        .nonempty({ message: t("validation.required") })
+        .min(8, { message: t("validation.passwordMin", { count: 8 }) }),
+      confirmPassword: z.string().nonempty({ message: t("validation.required") }),
+    })
+    .refine((data) => data.password === data.confirmPassword, {
+      message: t("validation.passwordMismatch"),
+      path: ["confirmPassword"],
+    });
+
+  type FormValues = z.infer<typeof formSchema>;
+  const formMethods = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { password: "", confirmPassword: "" },
+  });
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (data: FormValues) =>
+      account.updateRecovery(userId, secret, data.password),
+    onSuccess: () => navigate({ to: "/recover/success" }),
+    onError: (err: any) => toast.error(err.message),
+  });
+
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-muted py-6 md:py-10">
+      <div className="w-full max-w-sm">
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex flex-col gap-6">
+              <div className="flex flex-col items-center text-center">
+                <h1 className="text-2xl font-bold">{t("resetPassword.title")}</h1>
+              </div>
+              <Form {...formMethods}>
+                <form
+                  className="grid gap-6"
+                  onSubmit={formMethods.handleSubmit((values) => mutate(values))}
+                >
+                  <FormField
+                    control={formMethods.control}
+                    name="password"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("resetPassword.password")}</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="password"
+                            placeholder={t("resetPassword.passwordPlaceholder")}
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={formMethods.control}
+                    name="confirmPassword"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("resetPassword.confirmPassword")}</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="password"
+                            placeholder={t("resetPassword.confirmPasswordPlaceholder")}
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <Button
+                    loading={
+                      isPending ? `${t("feedback.loading")}...` : undefined
+                    }
+                    type="submit"
+                    className="w-full"
+                  >
+                    {t("resetPassword.submit")}
+                  </Button>
+                </form>
+              </Form>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/__authenticationLayout/recover/success.tsx
+++ b/src/routes/__authenticationLayout/recover/success.tsx
@@ -1,0 +1,31 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useTranslate } from "@tolgee/react";
+
+export const Route = createFileRoute("/__authenticationLayout/recover/success")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { t } = useTranslate();
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-muted py-6 md:py-10">
+      <div className="w-full max-w-sm">
+        <Card>
+          <CardContent className="p-6 text-center flex flex-col gap-4">
+            <h1 className="text-2xl font-bold">
+              {t("passwordChanged.title")}
+            </h1>
+            <p className="text-balance text-muted-foreground">
+              {t("passwordChanged.description")}
+            </p>
+            <Link to="/login">
+              <Button className="w-full">{t("passwordChanged.login")}</Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -23,6 +23,8 @@
     "agreeTo": "By clicking continue, you agree to our",
     "and": "and",
     "dontHaveAccount": "Don't have an account?",
+    "forgotPassword": "Forgot your password?",
+    "recover": "Recover it",
     "email": "Email",
     "email-placeholder": "Write here...",
     "login": "Login",
@@ -57,6 +59,27 @@
     "signUpWithGoogle": "Sign up with Google",
     "termsOfService": "Terms of Service"
   },
+  "recover": {
+    "title": "Recover password",
+    "description": "Enter your email to receive a recovery link",
+    "email": "Email",
+    "emailPlaceholder": "Write here...",
+    "submit": "Send recovery email",
+    "success": "Recovery email sent"
+  },
+  "resetPassword": {
+    "title": "Reset password",
+    "password": "New password",
+    "passwordPlaceholder": "Write here...",
+    "confirmPassword": "Confirm new password",
+    "confirmPasswordPlaceholder": "Write here...",
+    "submit": "Change password"
+  },
+  "passwordChanged": {
+    "title": "Password changed",
+    "description": "You can now log in with your new password.",
+    "login": "Go to login"
+  },
   "waitlist": {
     "title": "Join the waitlist",
     "description": "Be the first to know when we launch.",
@@ -90,6 +113,7 @@
   "validation": {
     "invalidEmail": "Invalid email",
     "passwordMin": "Minimum {{count}} characters",
+    "passwordMismatch": "Passwords don't match",
     "required": "Required field"
   }
 }

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -22,6 +22,8 @@
     "agreeTo": "Ao clicar em continuar, você concorda com nossos",
     "and": "e",
     "dontHaveAccount": "Não tem uma conta?",
+    "forgotPassword": "Esqueceu sua senha?",
+    "recover": "Recupere",
     "email": "Email",
     "email-placeholder": "Digite aqui...",
     "login": "Entrar",
@@ -56,6 +58,27 @@
     "signUpWithGoogle": "Cadastre-se com Google",
     "termsOfService": "Termos de Serviço"
   },
+  "recover": {
+    "title": "Recuperar senha",
+    "description": "Digite seu email para receber um link de recuperação",
+    "email": "Email",
+    "emailPlaceholder": "Digite aqui...",
+    "submit": "Enviar email de recuperação",
+    "success": "Email de recuperação enviado"
+  },
+  "resetPassword": {
+    "title": "Redefinir senha",
+    "password": "Nova senha",
+    "passwordPlaceholder": "Digite aqui...",
+    "confirmPassword": "Confirmar nova senha",
+    "confirmPasswordPlaceholder": "Digite aqui...",
+    "submit": "Alterar senha"
+  },
+  "passwordChanged": {
+    "title": "Senha alterada",
+    "description": "Agora você pode entrar com sua nova senha.",
+    "login": "Ir para o login"
+  },
   "waitlist": {
     "title": "Entre na lista de espera",
     "description": "Seja o primeiro a saber quando lançarmos.",
@@ -89,6 +112,7 @@
   "validation": {
     "invalidEmail": "Email inválido",
     "passwordMin": "Mínimo de {{count}} caracteres",
+    "passwordMismatch": "As senhas não coincidem",
     "required": "Campo obrigatório"
   }
 }


### PR DESCRIPTION
## Summary
- add pages for requesting, resetting, and confirming password recovery
- link to recovery from login screen
- localize recovery strings in English and Portuguese

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a12977a708832e907944d6670f8cc2