### PR TITLE
feat: add mascots to password recovery flow

### DIFF
--- a/src/routes/__authenticationLayout/recover/index.tsx
+++ b/src/routes/__authenticationLayout/recover/index.tsx
@@ -56,7 +56,12 @@ function RouteComponent() {
         <Card>
           <CardContent className="p-6">
             <div className="flex flex-col gap-6">
-              <div className="flex flex-col items-center text-center">
+              <div className="flex flex-col items-center gap-6 text-center">
+                <img
+                  src="/assets/mascot/mascot_worried_face.png"
+                  alt={t("recover.title")}
+                  className="w-40"
+                />
                 <h1 className="text-2xl font-bold">{t("recover.title")}</h1>
                 <p className="text-balance text-muted-foreground">
                   {t("recover.description")}

--- a/src/routes/__authenticationLayout/recover/reset.tsx
+++ b/src/routes/__authenticationLayout/recover/reset.tsx
@@ -74,7 +74,12 @@ function RouteComponent() {
         <Card>
           <CardContent className="p-6">
             <div className="flex flex-col gap-6">
-              <div className="flex flex-col items-center text-center">
+              <div className="flex flex-col items-center gap-6 text-center">
+                <img
+                  src="/assets/mascot/mascot_sad_face.png"
+                  alt={t("resetPassword.title")}
+                  className="w-40"
+                />
                 <h1 className="text-2xl font-bold">{t("resetPassword.title")}</h1>
               </div>
               <Form {...formMethods}>

--- a/src/routes/__authenticationLayout/recover/success.tsx
+++ b/src/routes/__authenticationLayout/recover/success.tsx
@@ -13,7 +13,12 @@ function RouteComponent() {
     <div className="flex min-h-dvh flex-col items-center justify-center bg-muted py-6 md:py-10">
       <div className="w-full max-w-sm">
         <Card>
-          <CardContent className="p-6 text-center flex flex-col gap-4">
+          <CardContent className="p-6 text-center flex flex-col items-center gap-6">
+            <img
+              src="/assets/mascot/mascot_satisfied_face.png"
+              alt={t("passwordChanged.title")}
+              className="w-40"
+            />
             <h1 className="text-2xl font-bold">
               {t("passwordChanged.title")}
             </h1>


### PR DESCRIPTION
## Summary
- add worried mascot to password recovery request page
- show sad mascot on password reset form
- display satisfied mascot after successful password change

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a13a8ca414832eaf1067e30c0efb86