### PR TITLE
feat: add account settings page

### DIFF
--- a/src/components/password-prompt.tsx
+++ b/src/components/password-prompt.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface PasswordPromptProps {
+  open: boolean;
+  onConfirm: (password: string) => void;
+  onCancel: () => void;
+}
+
+export function PasswordPrompt({ open, onConfirm, onCancel }: PasswordPromptProps) {
+  const [password, setPassword] = useState("");
+
+  const handleClose = () => {
+    setPassword("");
+    onCancel();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Confirm Password</DialogTitle>
+          <DialogDescription>
+            Enter your current password to continue.
+          </DialogDescription>
+        </DialogHeader>
+        <Input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+        />
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              onConfirm(password);
+              setPassword("");
+            }}
+          >
+            Confirm
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default PasswordPrompt;

--- a/src/components/sidebar/nav-user.test.tsx
+++ b/src/components/sidebar/nav-user.test.tsx
@@ -12,6 +12,7 @@ vi.mock('@tanstack/react-query', () => ({
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => () => {},
+  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
 }))
 
 vi.mock('@/lib/appwrite', () => ({

--- a/src/components/sidebar/nav-user.tsx
+++ b/src/components/sidebar/nav-user.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronsUpDown, LogOut } from "lucide-react";
+import { ChevronsUpDown, LogOut, Settings } from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
@@ -21,7 +21,7 @@ import useSession from "@/hooks/queries/user";
 import { account } from "@/lib/appwrite";
 import { getInitials } from "@/lib/utils";
 import { useMutation } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 
 const LogoutItem = () => {
@@ -108,29 +108,13 @@ export function NavUser() {
               </div>
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
-            {/*             
-            <DropdownMenuGroup>
-              <DropdownMenuItem>
-                <Sparkles />
-                Upgrade to Pro
-              </DropdownMenuItem>
-            </DropdownMenuGroup>
+            <DropdownMenuItem asChild>
+              <Link to="/settings">
+                <Settings />
+                Settings
+              </Link>
+            </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuGroup>
-              <DropdownMenuItem>
-                <BadgeCheck />
-                Account
-              </DropdownMenuItem>
-              <DropdownMenuItem>
-                <CreditCard />
-                Billing
-              </DropdownMenuItem>
-              <DropdownMenuItem>
-                <Bell />
-                Notifications
-              </DropdownMenuItem>
-            </DropdownMenuGroup>
-            <DropdownMenuSeparator /> */}
             <LogoutItem />
           </DropdownMenuContent>
         </DropdownMenu>

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as _authenticatedLayoutRouteImport } from './routes/__authenticat
 import { Route as _authenticatedLayoutIndexRouteImport } from './routes/__authenticatedLayout/index'
 import { Route as _authenticationLayoutRegisterRouteImport } from './routes/__authenticationLayout/register'
 import { Route as _authenticationLayoutLoginRouteImport } from './routes/__authenticationLayout/login'
+import { Route as _authenticatedLayoutSettingsRouteImport } from './routes/__authenticatedLayout/settings'
 import { Route as _authenticatedLayoutHomeRouteImport } from './routes/__authenticatedLayout/home'
 import { Route as _authenticatedLayoutChatRouteImport } from './routes/__authenticatedLayout/chat'
 import { Route as _authenticationLayoutRecoverIndexRouteImport } from './routes/__authenticationLayout/recover/index'
@@ -70,6 +71,12 @@ const _authenticationLayoutLoginRoute =
     path: '/login',
     getParentRoute: () => _authenticationLayoutRoute,
   } as any)
+const _authenticatedLayoutSettingsRoute =
+  _authenticatedLayoutSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => _authenticatedLayoutRoute,
+  } as any)
 const _authenticatedLayoutHomeRoute =
   _authenticatedLayoutHomeRouteImport.update({
     id: '/home',
@@ -108,6 +115,7 @@ export interface FileRoutesByFullPath {
   '/waitlist-drawer-test': typeof WaitlistDrawerTestRoute
   '/chat': typeof _authenticatedLayoutChatRoute
   '/home': typeof _authenticatedLayoutHomeRoute
+  '/settings': typeof _authenticatedLayoutSettingsRoute
   '/login': typeof _authenticationLayoutLoginRoute
   '/register': typeof _authenticationLayoutRegisterRoute
   '/': typeof _authenticatedLayoutIndexRoute
@@ -122,6 +130,7 @@ export interface FileRoutesByTo {
   '/waitlist-drawer-test': typeof WaitlistDrawerTestRoute
   '/chat': typeof _authenticatedLayoutChatRoute
   '/home': typeof _authenticatedLayoutHomeRoute
+  '/settings': typeof _authenticatedLayoutSettingsRoute
   '/login': typeof _authenticationLayoutLoginRoute
   '/register': typeof _authenticationLayoutRegisterRoute
   '/': typeof _authenticatedLayoutIndexRoute
@@ -139,6 +148,7 @@ export interface FileRoutesById {
   '/waitlist-drawer-test': typeof WaitlistDrawerTestRoute
   '/__authenticatedLayout/chat': typeof _authenticatedLayoutChatRoute
   '/__authenticatedLayout/home': typeof _authenticatedLayoutHomeRoute
+  '/__authenticatedLayout/settings': typeof _authenticatedLayoutSettingsRoute
   '/__authenticationLayout/login': typeof _authenticationLayoutLoginRoute
   '/__authenticationLayout/register': typeof _authenticationLayoutRegisterRoute
   '/__authenticatedLayout/': typeof _authenticatedLayoutIndexRoute
@@ -155,6 +165,7 @@ export interface FileRouteTypes {
     | '/waitlist-drawer-test'
     | '/chat'
     | '/home'
+    | '/settings'
     | '/login'
     | '/register'
     | '/'
@@ -169,6 +180,7 @@ export interface FileRouteTypes {
     | '/waitlist-drawer-test'
     | '/chat'
     | '/home'
+    | '/settings'
     | '/login'
     | '/register'
     | '/'
@@ -185,6 +197,7 @@ export interface FileRouteTypes {
     | '/waitlist-drawer-test'
     | '/__authenticatedLayout/chat'
     | '/__authenticatedLayout/home'
+    | '/__authenticatedLayout/settings'
     | '/__authenticationLayout/login'
     | '/__authenticationLayout/register'
     | '/__authenticatedLayout/'
@@ -267,6 +280,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof _authenticationLayoutLoginRouteImport
       parentRoute: typeof _authenticationLayoutRoute
     }
+    '/__authenticatedLayout/settings': {
+      id: '/__authenticatedLayout/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof _authenticatedLayoutSettingsRouteImport
+      parentRoute: typeof _authenticatedLayoutRoute
+    }
     '/__authenticatedLayout/home': {
       id: '/__authenticatedLayout/home'
       path: '/home'
@@ -308,12 +328,14 @@ declare module '@tanstack/react-router' {
 interface _authenticatedLayoutRouteChildren {
   _authenticatedLayoutChatRoute: typeof _authenticatedLayoutChatRoute
   _authenticatedLayoutHomeRoute: typeof _authenticatedLayoutHomeRoute
+  _authenticatedLayoutSettingsRoute: typeof _authenticatedLayoutSettingsRoute
   _authenticatedLayoutIndexRoute: typeof _authenticatedLayoutIndexRoute
 }
 
 const _authenticatedLayoutRouteChildren: _authenticatedLayoutRouteChildren = {
   _authenticatedLayoutChatRoute: _authenticatedLayoutChatRoute,
   _authenticatedLayoutHomeRoute: _authenticatedLayoutHomeRoute,
+  _authenticatedLayoutSettingsRoute: _authenticatedLayoutSettingsRoute,
   _authenticatedLayoutIndexRoute: _authenticatedLayoutIndexRoute,
 }
 

--- a/src/routes/__authenticatedLayout/settings.tsx
+++ b/src/routes/__authenticatedLayout/settings.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useState } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { PasswordPrompt } from "@/components/password-prompt";
+import { account } from "@/lib/appwrite";
+import useSession from "@/hooks/queries/user";
+import { toast } from "sonner";
+
+export const Route = createFileRoute("/__authenticatedLayout/settings")({
+  component: SettingsPage,
+});
+
+function SettingsPage() {
+  const queryClient = useQueryClient();
+  const { data: session } = useSession();
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [prefs, setPrefs] = useState("{}");
+
+  useEffect(() => {
+    if (session) {
+      setName(session.name);
+      setEmail(session.email);
+      setPrefs(JSON.stringify(session.prefs ?? {}, null, 2));
+    }
+  }, [session]);
+
+  const nameMutation = useMutation({
+    mutationFn: (name: string) => account.updateName(name),
+    onSuccess: (data) => {
+      queryClient.setQueryData(["session"], data);
+      toast.success("Name updated");
+    },
+  });
+
+  const [pendingEmail, setPendingEmail] = useState("");
+  const [emailPromptOpen, setEmailPromptOpen] = useState(false);
+  const emailMutation = useMutation({
+    mutationFn: ({ email, password }: { email: string; password: string }) =>
+      account.updateEmail(email, password),
+    onSuccess: (data) => {
+      queryClient.setQueryData(["session"], data);
+      toast.success("Email updated");
+    },
+  });
+
+  const [pendingPassword, setPendingPassword] = useState("");
+  const [passwordPromptOpen, setPasswordPromptOpen] = useState(false);
+  const passwordMutation = useMutation({
+    mutationFn: ({ password, old }: { password: string; old: string }) =>
+      account.updatePassword(password, old),
+    onSuccess: () => {
+      toast.success("Password updated");
+    },
+  });
+
+  const prefsMutation = useMutation({
+    mutationFn: (prefs: Record<string, unknown>) => account.updatePrefs(prefs),
+    onSuccess: (data) => {
+      queryClient.setQueryData(["session"], data);
+      toast.success("Preferences updated");
+    },
+  });
+
+  const sessionsQuery = useQuery({
+    queryKey: ["sessions"],
+    queryFn: () => account.listSessions().then((res: any) => res.sessions),
+  });
+
+  const deleteSessionMutation = useMutation({
+    mutationFn: (id: string) => account.deleteSession(id),
+    onSuccess: () => {
+      toast.success("Session deleted");
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+    },
+  });
+
+  return (
+    <div className="max-w-xl mx-auto space-y-10">
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Profile</h2>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            nameMutation.mutate(name);
+          }}
+          className="space-y-2"
+        >
+          <Input value={name} onChange={(e) => setName(e.target.value)} />
+          <Button type="submit" disabled={nameMutation.isPending}>
+            Save name
+          </Button>
+        </form>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Email</h2>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            setPendingEmail(email);
+            setEmailPromptOpen(true);
+          }}
+          className="space-y-2"
+        >
+          <Input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <Button type="submit" disabled={emailMutation.isPending}>
+            Save email
+          </Button>
+        </form>
+        <PasswordPrompt
+          open={emailPromptOpen}
+          onCancel={() => setEmailPromptOpen(false)}
+          onConfirm={(password) => {
+            emailMutation.mutate({ email: pendingEmail, password });
+            setEmailPromptOpen(false);
+          }}
+        />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Password</h2>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            setPendingPassword(pendingPassword);
+            setPasswordPromptOpen(true);
+          }}
+          className="space-y-2"
+        >
+          <Input
+            type="password"
+            value={pendingPassword}
+            onChange={(e) => setPendingPassword(e.target.value)}
+            placeholder="New password"
+          />
+          <Button type="submit" disabled={passwordMutation.isPending}>
+            Change password
+          </Button>
+        </form>
+        <PasswordPrompt
+          open={passwordPromptOpen}
+          onCancel={() => setPasswordPromptOpen(false)}
+          onConfirm={(oldPassword) => {
+            passwordMutation.mutate({ password: pendingPassword, old: oldPassword });
+            setPasswordPromptOpen(false);
+            setPendingPassword("");
+          }}
+        />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Preferences</h2>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            try {
+              const parsed = JSON.parse(prefs);
+              prefsMutation.mutate(parsed);
+            } catch {
+              toast.error("Invalid JSON");
+            }
+          }}
+          className="space-y-2"
+        >
+          <Textarea
+            value={prefs}
+            onChange={(e) => setPrefs(e.target.value)}
+            rows={5}
+          />
+          <Button type="submit" disabled={prefsMutation.isPending}>
+            Save preferences
+          </Button>
+        </form>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Active Sessions</h2>
+        <ul className="space-y-2">
+          {sessionsQuery.data?.map((s: any) => (
+            <li
+              key={s.$id}
+              className="flex items-center justify-between rounded-md border p-2"
+            >
+              <div>
+                <p className="font-medium">
+                  {s.clientName || "Unknown"} {s.osName ? `- ${s.osName}` : ""}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Expires {new Date(s.expire * 1000).toLocaleString()}
+                </p>
+              </div>
+              {s.current ? (
+                <span className="text-xs text-muted-foreground">Current</span>
+              ) : (
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => deleteSessionMutation.mutate(s.$id)}
+                  disabled={deleteSessionMutation.isPending}
+                >
+                  Delete
+                </Button>
+              )}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable password confirmation prompt
- implement account settings page with profile, email, password, preferences and session management
- link settings from sidebar user menu

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a13a051e24832e91a6458d69172664